### PR TITLE
groupby isin to work with quotes.json properly

### DIFF
--- a/benchmark/calcValueHistory/index.js
+++ b/benchmark/calcValueHistory/index.js
@@ -7,8 +7,8 @@ const quotes = require('./fixtures/quotes.json')
 
 const calcValueHistory = require('../../src/calcValueHistory')
 
-const activitiesFilered = activities.filter(a => ['Buy', 'Sell', 'split'].includes(a.type))
-const activitiesByHolding = groupBy(activitiesFilered, 'holding')
+const activitiesFiltered = activities.filter(a => ['Buy', 'Sell', 'split'].includes(a.type))
+const activitiesByHolding = groupBy(activitiesFiltered, 'isin')
 
 function getEarliestActivity (values) {
   const earliest = minBy(values, x => new Date(x.date)) || {}

--- a/utils.js
+++ b/utils.js
@@ -39,7 +39,7 @@ function getDateArr (interval) {
   const endDate = new Date(parse(interval.end, 'yyyy-MM-dd', new Date()))
   const eachDay = eachDayOfInterval({ start: startDate, end: endDate })
 
-  const dateArr = eachDay.map((d, i) => format(d, 'yyyy-MM-dd'))
+  const dateArr = eachDay.map((d, i) => d.toString().split('T')[0])
 
   return dateArr
 }


### PR DESCRIPTION
the "groupby" in the benchmark has using a oid called holding, but in the quotes we have "isin" as a key