### PR TITLE
parse date of mock data properly

### DIFF
--- a/benchmark/calcValueHistory/fixtures/activities.json
+++ b/benchmark/calcValueHistory/fixtures/activities.json
@@ -7,9 +7,7 @@
   "type": "Sell",
   "company": "HSBC",
   "symbol": "",
-  "date": {
-    "$date": "2015-06-05T00:00:00Z"
-  },
+  "date": "2015-06-05",
   "shares": 265,
   "amount": 2234.82,
   "grossAmount": 0,
@@ -30,9 +28,7 @@
   "type": "Buy",
   "company": "HSBC",
   "symbol": "",
-  "date": {
-    "$date": "2014-01-29T00:00:00Z"
-  },
+  "date": "2014-01-29",
   "shares": 265,
   "amount": 2016.29,
   "grossAmount": 0,
@@ -53,9 +49,7 @@
   "type": "Sell",
   "company": "British American Tobacco",
   "symbol": "BATS.L",
-  "date": {
-    "$date": "2016-08-19T00:00:00Z"
-  },
+  "date": "2016-08-19",
   "shares": 40,
   "amount": 2235.47,
   "grossAmount": 192413.61,
@@ -76,9 +70,7 @@
   "type": "Buy",
   "company": "British American Tobacco",
   "symbol": "BATS.L",
-  "date": {
-    "$date": "2014-01-14T00:00:00Z"
-  },
+  "date": "2014-01-14",
   "shares": 40,
   "amount": 1480.78,
   "grossAmount": 123119.45,
@@ -99,9 +91,7 @@
   "type": "Sell",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2014-06-10T00:00:00Z"
-  },
+  "date": "2014-06-10",
   "shares": 44,
   "amount": 1549.11,
   "grossAmount": 2098.58,
@@ -122,9 +112,7 @@
   "type": "Buy",
   "company": "Orkla",
   "symbol": "OKL.F",
-  "date": {
-    "$date": "2013-10-18T00:00:00Z"
-  },
+  "date": "2013-10-18",
   "shares": 360,
   "amount": 1998.9,
   "grossAmount": 0,
@@ -145,9 +133,7 @@
   "type": "Sell",
   "company": "Orkla",
   "symbol": "OKL.F",
-  "date": {
-    "$date": "2016-02-03T00:00:00Z"
-  },
+  "date": "2016-02-03",
   "shares": 360,
   "amount": 2425.84,
   "grossAmount": 0,
@@ -168,9 +154,7 @@
   "type": "Sell",
   "company": "AstraZeneca",
   "symbol": "",
-  "date": {
-    "$date": "2013-03-22T00:00:00Z"
-  },
+  "date": "2013-03-22",
   "shares": 55,
   "amount": 2059.57,
   "grossAmount": 0,
@@ -191,9 +175,7 @@
   "type": "Buy",
   "company": "AstraZeneca",
   "symbol": "",
-  "date": {
-    "$date": "2011-03-01T00:00:00Z"
-  },
+  "date": "2011-03-01",
   "shares": 55,
   "amount": 1994.25,
   "grossAmount": 0,
@@ -214,9 +196,7 @@
   "type": "Buy",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2013-06-26T00:00:00Z"
-  },
+  "date": "2013-06-26",
   "shares": 49,
   "amount": 1995.87,
   "grossAmount": 2599.42,
@@ -237,9 +217,7 @@
   "type": "Buy",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2013-04-17T00:00:00Z"
-  },
+  "date": "2013-04-17",
   "shares": 61,
   "amount": 2020.09,
   "grossAmount": 0,
@@ -260,9 +238,7 @@
   "type": "Sell",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2016-02-01T00:00:00Z"
-  },
+  "date": "2016-02-01",
   "shares": 49,
   "amount": 1245.64,
   "grossAmount": 1360.24,
@@ -283,9 +259,7 @@
   "type": "Sell",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2015-08-20T00:00:00Z"
-  },
+  "date": "2015-08-20",
   "shares": 61,
   "amount": 2046.95,
   "grossAmount": 0,
@@ -306,9 +280,7 @@
   "type": "Buy",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2016-07-28T00:00:00Z"
-  },
+  "date": "2016-07-28",
   "shares": 103,
   "amount": 1502.58,
   "grossAmount": 1651.49,
@@ -329,9 +301,7 @@
   "type": "Buy",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2013-01-14T00:00:00Z"
-  },
+  "date": "2013-01-14",
   "shares": 100,
   "amount": 2023.6,
   "grossAmount": 2699.68,
@@ -352,9 +322,7 @@
   "type": "Sell",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2015-01-23T00:00:00Z"
-  },
+  "date": "2015-01-23",
   "shares": 25,
   "amount": 1042,
   "grossAmount": 1166.83,
@@ -375,9 +343,7 @@
   "type": "Buy",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2011-02-01T00:00:00Z"
-  },
+  "date": "2011-02-01",
   "shares": 92,
   "amount": 2018.72,
   "grossAmount": 0,
@@ -398,9 +364,7 @@
   "type": "Buy",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2019-01-10T00:00:00Z"
-  },
+  "date": "2019-01-10",
   "shares": 43,
   "amount": 1997.3,
   "grossAmount": 0,
@@ -421,9 +385,7 @@
   "type": "Buy",
   "company": "Total",
   "symbol": "",
-  "date": {
-    "$date": "2011-05-25T00:00:00Z"
-  },
+  "date": "2011-05-25",
   "shares": 51,
   "amount": 2009.56,
   "grossAmount": 0,
@@ -444,9 +406,7 @@
   "type": "Sell",
   "company": "Total",
   "symbol": "",
-  "date": {
-    "$date": "2013-05-28T00:00:00Z"
-  },
+  "date": "2013-05-28",
   "shares": 51,
   "amount": 2037.62,
   "grossAmount": 0,
@@ -467,9 +427,7 @@
   "type": "Buy",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2020-01-08T00:00:00Z"
-  },
+  "date": "2020-01-08",
   "shares": 20,
   "amount": 1000.3,
   "grossAmount": 0,
@@ -490,9 +448,7 @@
   "type": "Buy",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2011-02-11T00:00:00Z"
-  },
+  "date": "2011-02-11",
   "shares": 50,
   "amount": 1998.49,
   "grossAmount": 0,
@@ -513,9 +469,7 @@
   "type": "Sell",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2015-02-05T00:00:00Z"
-  },
+  "date": "2015-02-05",
   "shares": 50,
   "amount": 2982.23,
   "grossAmount": 0,
@@ -536,9 +490,7 @@
   "type": "Buy",
   "company": "RECKITT BENCK.GRP LS -,10",
   "symbol": "RB.L",
-  "date": {
-    "$date": "2019-07-31T00:00:00Z"
-  },
+  "date": "2019-07-31",
   "shares": 35,
   "amount": 2466.64,
   "grossAmount": 226000.96,
@@ -559,9 +511,7 @@
   "type": "Buy",
   "company": "RECKITT BENCK.GRP LS -,10",
   "symbol": "RB.L",
-  "date": {
-    "$date": "2019-10-22T00:00:00Z"
-  },
+  "date": "2019-10-22",
   "shares": 23,
   "amount": 1514.47,
   "grossAmount": 130138.41,
@@ -582,9 +532,7 @@
   "type": "Sell",
   "company": "Munich Re",
   "symbol": "MUV2.DE",
-  "date": {
-    "$date": "2016-01-14T00:00:00Z"
-  },
+  "date": "2016-01-14",
   "shares": 20,
   "amount": 3182.57,
   "grossAmount": 0,
@@ -605,9 +553,7 @@
   "type": "Buy",
   "company": "Munich Re",
   "symbol": "MUV2.DE",
-  "date": {
-    "$date": "2011-03-15T00:00:00Z"
-  },
+  "date": "2011-03-15",
   "shares": 20,
   "amount": 2115.88,
   "grossAmount": 0,
@@ -628,9 +574,7 @@
   "type": "Buy",
   "company": "RECKITT BENCK.GRP LS -,10",
   "symbol": "RB.L",
-  "date": {
-    "$date": "2019-08-07T00:00:00Z"
-  },
+  "date": "2019-08-07",
   "shares": 25,
   "amount": 1632.96,
   "grossAmount": 150808.75,
@@ -651,9 +595,7 @@
   "type": "Buy",
   "company": "\"White Mountains \"",
   "symbol": "WTM",
-  "date": {
-    "$date": "2013-03-15T00:00:00Z"
-  },
+  "date": "2013-03-15",
   "shares": 3,
   "amount": 1321.53,
   "grossAmount": 1729.35,
@@ -674,9 +616,7 @@
   "type": "Sell",
   "company": "\"White Mountains \"",
   "symbol": "WTM",
-  "date": {
-    "$date": "2016-02-01T00:00:00Z"
-  },
+  "date": "2016-02-01",
   "shares": 3,
   "amount": 1910.9,
   "grossAmount": 2086.7,
@@ -697,9 +637,7 @@
   "type": "Sell",
   "company": "\"Jardine Matheson \"",
   "symbol": "J36.SI",
-  "date": {
-    "$date": "2016-08-03T00:00:00Z"
-  },
+  "date": "2016-08-03",
   "shares": 50,
   "amount": 2391.97,
   "grossAmount": 2677.33,
@@ -720,9 +658,7 @@
   "type": "Buy",
   "company": "\"Jardine Matheson \"",
   "symbol": "J36.SI",
-  "date": {
-    "$date": "2013-08-08T00:00:00Z"
-  },
+  "date": "2013-08-08",
   "shares": 50,
   "amount": 2050.8,
   "grossAmount": 2739.87,
@@ -743,9 +679,7 @@
   "type": "Buy",
   "company": "First Pacific",
   "symbol": "0142.HK",
-  "date": {
-    "$date": "2014-02-25T00:00:00Z"
-  },
+  "date": "2014-02-25",
   "shares": 2000,
   "amount": 1501.34,
   "grossAmount": 16021.55,
@@ -766,9 +700,7 @@
   "type": "Buy",
   "company": "First Pacific",
   "symbol": "0142.HK",
-  "date": {
-    "$date": "2014-01-17T00:00:00Z"
-  },
+  "date": "2014-01-17",
   "shares": 2000,
   "amount": 1616.23,
   "grossAmount": 17027.47,
@@ -789,9 +721,7 @@
   "type": "Sell",
   "company": "First Pacific",
   "symbol": "0142.HK",
-  "date": {
-    "$date": "2016-02-16T00:00:00Z"
-  },
+  "date": "2016-02-16",
   "shares": 4000,
   "amount": 2426.5,
   "grossAmount": 21098.42,
@@ -812,9 +742,7 @@
   "type": "Buy",
   "company": "Dundee Corporation",
   "symbol": "",
-  "date": {
-    "$date": "2013-12-20T00:00:00Z"
-  },
+  "date": "2013-12-20",
   "shares": 160,
   "amount": 2060.6,
   "grossAmount": 0,
@@ -835,9 +763,7 @@
   "type": "Buy",
   "company": "Dundee Corporation",
   "symbol": "",
-  "date": {
-    "$date": "2014-02-18T00:00:00Z"
-  },
+  "date": "2014-02-18",
   "shares": 170,
   "amount": 2028.99,
   "grossAmount": 0,
@@ -858,9 +784,7 @@
   "type": "Sell",
   "company": "Dundee Corporation",
   "symbol": "",
-  "date": {
-    "$date": "2015-06-01T00:00:00Z"
-  },
+  "date": "2015-06-01",
   "shares": 330,
   "amount": 2689.55,
   "grossAmount": 0,
@@ -881,9 +805,7 @@
   "type": "Buy",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2011-04-04T00:00:00Z"
-  },
+  "date": "2011-04-04",
   "shares": 46,
   "amount": 2017.44,
   "grossAmount": 0,
@@ -904,9 +826,7 @@
   "type": "Sell",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2015-06-05T00:00:00Z"
-  },
+  "date": "2015-06-05",
   "shares": 46,
   "amount": 2882.19,
   "grossAmount": 0,
@@ -927,9 +847,7 @@
   "type": "Buy",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2011-04-04T00:00:00Z"
-  },
+  "date": "2011-04-04",
   "shares": 147,
   "amount": 2013.51,
   "grossAmount": 0,
@@ -950,9 +868,7 @@
   "type": "Sell",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2016-06-02T00:00:00Z"
-  },
+  "date": "2016-06-02",
   "shares": 100,
   "amount": 2409.61,
   "grossAmount": 0,
@@ -973,9 +889,7 @@
   "type": "Sell",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2015-01-23T00:00:00Z"
-  },
+  "date": "2015-01-23",
   "shares": 47,
   "amount": 1529.12,
   "grossAmount": 0,
@@ -996,9 +910,7 @@
   "type": "Sell",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2015-02-05T00:00:00Z"
-  },
+  "date": "2015-02-05",
   "shares": 45,
   "amount": 3328.4,
   "grossAmount": 0,
@@ -1019,9 +931,7 @@
   "type": "Buy",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2011-07-27T00:00:00Z"
-  },
+  "date": "2011-07-27",
   "shares": 45,
   "amount": 2020.01,
   "grossAmount": 0,
@@ -1042,9 +952,7 @@
   "type": "Buy",
   "company": "PEPSICO INC. DL-,0166",
   "symbol": "PEP",
-  "date": {
-    "$date": "2020-07-17T00:00:00Z"
-  },
+  "date": "2020-07-17",
   "shares": 9,
   "amount": 1055.34,
   "grossAmount": 1204.56,
@@ -1065,9 +973,7 @@
   "type": "Buy",
   "company": "PEPSICO INC. DL-,0166",
   "symbol": "PEP",
-  "date": {
-    "$date": "2020-09-11T00:00:00Z"
-  },
+  "date": "2020-09-11",
   "shares": 9,
   "amount": 1027.44,
   "grossAmount": 1217.41,
@@ -1088,9 +994,7 @@
   "type": "Buy",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2011-08-03T00:00:00Z"
-  },
+  "date": "2011-08-03",
   "shares": 55,
   "amount": 2007.94,
   "grossAmount": 0,
@@ -1111,9 +1015,7 @@
   "type": "Sell",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2016-03-09T00:00:00Z"
-  },
+  "date": "2016-03-09",
   "shares": 40,
   "amount": 2237.07,
   "grossAmount": 0,
@@ -1134,9 +1036,7 @@
   "type": "Sell",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2015-01-23T00:00:00Z"
-  },
+  "date": "2015-01-23",
   "shares": 15,
   "amount": 1037.64,
   "grossAmount": 0,
@@ -1157,9 +1057,7 @@
   "type": "Buy",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2011-08-05T00:00:00Z"
-  },
+  "date": "2011-08-05",
   "shares": 88,
   "amount": 1996.06,
   "grossAmount": 0,
@@ -1180,9 +1078,7 @@
   "type": "Buy",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2013-10-11T00:00:00Z"
-  },
+  "date": "2013-10-11",
   "shares": 83,
   "amount": 1980.4,
   "grossAmount": 0,
@@ -1203,9 +1099,7 @@
   "type": "Sell",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2016-03-09T00:00:00Z"
-  },
+  "date": "2016-03-09",
   "shares": 171,
   "amount": 3728.16,
   "grossAmount": 0,
@@ -1226,9 +1120,7 @@
   "type": "Buy",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2011-08-25T00:00:00Z"
-  },
+  "date": "2011-08-25",
   "shares": 70,
   "amount": 2004.1,
   "grossAmount": 0,
@@ -1249,9 +1141,7 @@
   "type": "Buy",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 10,
   "amount": 675,
   "grossAmount": 0,
@@ -1272,9 +1162,7 @@
   "type": "Buy",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2011-11-15T00:00:00Z"
-  },
+  "date": "2011-11-15",
   "shares": 75,
   "amount": 2013.4,
   "grossAmount": 0,
@@ -1295,9 +1183,7 @@
   "type": "Buy",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2013-07-25T00:00:00Z"
-  },
+  "date": "2013-07-25",
   "shares": 78,
   "amount": 1999.6,
   "grossAmount": 0,
@@ -1318,9 +1204,7 @@
   "type": "Sell",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2015-01-23T00:00:00Z"
-  },
+  "date": "2015-01-23",
   "shares": 23,
   "amount": 935.54,
   "grossAmount": 0,
@@ -1341,9 +1225,7 @@
   "type": "Sell",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2015-05-29T00:00:00Z"
-  },
+  "date": "2015-05-29",
   "shares": 63,
   "amount": 2598.64,
   "grossAmount": 0,
@@ -1364,9 +1246,7 @@
   "type": "Sell",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2015-11-20T00:00:00Z"
-  },
+  "date": "2015-11-20",
   "shares": 67,
   "amount": 2920.39,
   "grossAmount": 0,
@@ -1387,9 +1267,7 @@
   "type": "Buy",
   "company": "Tesco",
   "symbol": "",
-  "date": {
-    "$date": "2012-01-12T00:00:00Z"
-  },
+  "date": "2012-01-12",
   "shares": 500,
   "amount": 2014.9,
   "grossAmount": 0,
@@ -1410,9 +1288,7 @@
   "type": "Buy",
   "company": "Tesco",
   "symbol": "",
-  "date": {
-    "$date": "2012-05-29T00:00:00Z"
-  },
+  "date": "2012-05-29",
   "shares": 520,
   "amount": 2007.74,
   "grossAmount": 0,
@@ -1433,9 +1309,7 @@
   "type": "Sell",
   "company": "Tesco",
   "symbol": "",
-  "date": {
-    "$date": "2014-09-08T00:00:00Z"
-  },
+  "date": "2014-09-08",
   "shares": 1020,
   "amount": 2913.42,
   "grossAmount": 0,
@@ -1456,9 +1330,7 @@
   "type": "Buy",
   "company": "Philips",
   "symbol": "PHIA.AS",
-  "date": {
-    "$date": "2012-05-14T00:00:00Z"
-  },
+  "date": "2012-05-14",
   "shares": 140,
   "amount": 2034.3,
   "grossAmount": 0,
@@ -1479,9 +1351,7 @@
   "type": "Buy",
   "company": "Philips",
   "symbol": "PHIA.AS",
-  "date": {
-    "$date": "2013-06-06T00:00:00Z"
-  },
+  "date": "2013-06-06",
   "shares": 4.79032,
   "amount": 27.38,
   "grossAmount": 0,
@@ -1502,9 +1372,7 @@
   "type": "Sell",
   "company": "Philips",
   "symbol": "PHIA.AS",
-  "date": {
-    "$date": "2013-06-19T00:00:00Z"
-  },
+  "date": "2013-06-19",
   "shares": 0.79032,
   "amount": 15.71,
   "grossAmount": 0,
@@ -1525,9 +1393,7 @@
   "type": "Buy",
   "company": "Philips",
   "symbol": "PHIA.AS",
-  "date": {
-    "$date": "2014-06-04T00:00:00Z"
-  },
+  "date": "2014-06-04",
   "shares": 4.962,
   "amount": 32.24,
   "grossAmount": 0,
@@ -1548,9 +1414,7 @@
   "type": "Sell",
   "company": "Philips",
   "symbol": "PHIA.AS",
-  "date": {
-    "$date": "2014-06-11T00:00:00Z"
-  },
+  "date": "2014-06-11",
   "shares": 0.962,
   "amount": 22.96,
   "grossAmount": 0,
@@ -1571,9 +1435,7 @@
   "type": "Buy",
   "company": "Philips",
   "symbol": "PHIA.AS",
-  "date": {
-    "$date": "2015-06-11T00:00:00Z"
-  },
+  "date": "2015-06-11",
   "shares": 4.84723,
   "amount": 33.24,
   "grossAmount": 0,
@@ -1594,9 +1456,7 @@
   "type": "Sell",
   "company": "Philips",
   "symbol": "PHIA.AS",
-  "date": {
-    "$date": "2015-06-12T00:00:00Z"
-  },
+  "date": "2015-06-12",
   "shares": 0.84723,
   "amount": 18.43,
   "grossAmount": 0,
@@ -1617,9 +1477,7 @@
   "type": "Sell",
   "company": "Philips",
   "symbol": "PHIA.AS",
-  "date": {
-    "$date": "2016-01-26T00:00:00Z"
-  },
+  "date": "2016-01-26",
   "shares": 152,
   "amount": 3616.52,
   "grossAmount": 0,
@@ -1640,9 +1498,7 @@
   "type": "Buy",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2012-06-26T00:00:00Z"
-  },
+  "date": "2012-06-26",
   "shares": 143,
   "amount": 2008.39,
   "grossAmount": 17714.8,
@@ -1663,9 +1519,7 @@
   "type": "Buy",
   "company": "Siemens",
   "symbol": "SIE.DE",
-  "date": {
-    "$date": "2012-07-26T00:00:00Z"
-  },
+  "date": "2012-07-26",
   "shares": 31,
   "amount": 2024.31,
   "grossAmount": 0,
@@ -1686,9 +1540,7 @@
   "type": "Buy",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2016-03-10T00:00:00Z"
-  },
+  "date": "2016-03-10",
   "shares": 66,
   "amount": 2029.79,
   "grossAmount": 18860.81,
@@ -1709,9 +1561,7 @@
   "type": "Sell",
   "company": "Siemens",
   "symbol": "SIE.DE",
-  "date": {
-    "$date": "2016-01-26T00:00:00Z"
-  },
+  "date": "2016-01-26",
   "shares": 31,
   "amount": 2547.27,
   "grossAmount": 0,
@@ -1732,9 +1582,7 @@
   "type": "Buy",
   "company": "GBL",
   "symbol": "GBLB.BR",
-  "date": {
-    "$date": "2012-08-02T00:00:00Z"
-  },
+  "date": "2012-08-02",
   "shares": 37,
   "amount": 1984.91,
   "grossAmount": 0,
@@ -1755,9 +1603,7 @@
   "type": "Sell",
   "company": "GBL",
   "symbol": "GBLB.BR",
-  "date": {
-    "$date": "2016-07-13T00:00:00Z"
-  },
+  "date": "2016-07-13",
   "shares": 37,
   "amount": 2747.01,
   "grossAmount": 0,
@@ -1778,9 +1624,7 @@
   "type": "Buy",
   "company": "Vodafone",
   "symbol": "",
-  "date": {
-    "$date": "2011-03-01T00:00:00Z"
-  },
+  "date": "2011-03-01",
   "shares": 950,
   "amount": 2005.85,
   "grossAmount": 0,
@@ -1801,9 +1645,7 @@
   "type": "Sell",
   "company": "Vodafone",
   "symbol": "",
-  "date": {
-    "$date": "2013-09-25T00:00:00Z"
-  },
+  "date": "2013-09-25",
   "shares": 950,
   "amount": 2317.9,
   "grossAmount": 0,
@@ -1824,9 +1666,7 @@
   "type": "Buy",
   "company": "BAE Systems",
   "symbol": "",
-  "date": {
-    "$date": "2011-07-13T00:00:00Z"
-  },
+  "date": "2011-07-13",
   "shares": 570,
   "amount": 2004.7,
   "grossAmount": 0,
@@ -1847,9 +1687,7 @@
   "type": "Sell",
   "company": "BAE Systems",
   "symbol": "",
-  "date": {
-    "$date": "2014-05-13T00:00:00Z"
-  },
+  "date": "2014-05-13",
   "shares": 570,
   "amount": 2842.95,
   "grossAmount": 0,
@@ -1870,9 +1708,7 @@
   "type": "Buy",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2011-05-06T00:00:00Z"
-  },
+  "date": "2011-05-06",
   "shares": 70,
   "amount": 2016.17,
   "grossAmount": 0,
@@ -1893,9 +1729,7 @@
   "type": "Buy",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2012-11-05T00:00:00Z"
-  },
+  "date": "2012-11-05",
   "shares": 78,
   "amount": 1991.72,
   "grossAmount": 0,
@@ -1916,9 +1750,7 @@
   "type": "Sell",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2014-05-29T00:00:00Z"
-  },
+  "date": "2014-05-29",
   "shares": 148,
   "amount": 3901.89,
   "grossAmount": 0,
@@ -1939,9 +1771,7 @@
   "type": "Buy",
   "company": "Bollore",
   "symbol": "BOL.PA",
-  "date": {
-    "$date": "2014-10-13T00:00:00Z"
-  },
+  "date": "2014-10-13",
   "shares": 500,
   "amount": 1955.83,
   "grossAmount": 0,
@@ -1962,9 +1792,7 @@
   "type": "Sell",
   "company": "Bollore",
   "symbol": "BOL.PA",
-  "date": {
-    "$date": "2016-02-03T00:00:00Z"
-  },
+  "date": "2016-02-03",
   "shares": 500,
   "amount": 1749.1,
   "grossAmount": 0,
@@ -1985,9 +1813,7 @@
   "type": "Buy",
   "company": "\"Compagnie Financiere Richemont SA \"",
   "symbol": "CFR.SW",
-  "date": {
-    "$date": "2014-10-01T00:00:00Z"
-  },
+  "date": "2014-10-01",
   "shares": 31,
   "amount": 2001.5,
   "grossAmount": 2416.21,
@@ -2008,9 +1834,7 @@
   "type": "Buy",
   "company": "\"Compagnie Financiere Richemont SA \"",
   "symbol": "CFR.SW",
-  "date": {
-    "$date": "2016-01-14T00:00:00Z"
-  },
+  "date": "2016-01-14",
   "shares": 26,
   "amount": 1537.69,
   "grossAmount": 1683.77,
@@ -2031,9 +1855,7 @@
   "type": "Sell",
   "company": "\"Compagnie Financiere Richemont SA \"",
   "symbol": "CFR.SW",
-  "date": {
-    "$date": "2017-08-17T00:00:00Z"
-  },
+  "date": "2017-08-17",
   "shares": 85,
   "amount": 5893.04,
   "grossAmount": 6721.6,
@@ -2054,9 +1876,7 @@
   "type": "Buy",
   "company": "\"Compagnie Financiere Richemont SA \"",
   "symbol": "CFR.SW",
-  "date": {
-    "$date": "2016-05-20T00:00:00Z"
-  },
+  "date": "2016-05-20",
   "shares": 28,
   "amount": 1491.66,
   "grossAmount": 1654.1,
@@ -2077,9 +1897,7 @@
   "type": "Buy",
   "company": "Standard Chartered",
   "symbol": "2888.HK",
-  "date": {
-    "$date": "2014-12-16T00:00:00Z"
-  },
+  "date": "2014-12-16",
   "shares": 175,
   "amount": 2024.05,
   "grossAmount": 19674.98,
@@ -2100,9 +1918,7 @@
   "type": "Sell",
   "company": "Standard Chartered",
   "symbol": "2888.HK",
-  "date": {
-    "$date": "2016-01-26T00:00:00Z"
-  },
+  "date": "2016-01-26",
   "shares": 175,
   "amount": 1081.58,
   "grossAmount": 9139.13,
@@ -2123,9 +1939,7 @@
   "type": "Buy",
   "company": "Aker",
   "symbol": "FKM.F",
-  "date": {
-    "$date": "2015-01-05T00:00:00Z"
-  },
+  "date": "2015-01-05",
   "shares": 110,
   "amount": 2000.68,
   "grossAmount": 0,
@@ -2146,9 +1960,7 @@
   "type": "Sell",
   "company": "Aker",
   "symbol": "FKM.F",
-  "date": {
-    "$date": "2016-01-14T00:00:00Z"
-  },
+  "date": "2016-01-14",
   "shares": 110,
   "amount": 1713.47,
   "grossAmount": 0,
@@ -2169,9 +1981,7 @@
   "type": "Buy",
   "company": "Lundberg",
   "symbol": "LUND-B.ST",
-  "date": {
-    "$date": "2015-01-13T00:00:00Z"
-  },
+  "date": "2015-01-13",
   "shares": 55,
   "amount": 2007.03,
   "grossAmount": 18979.28,
@@ -2192,9 +2002,7 @@
   "type": "Sell",
   "company": "Lundberg",
   "symbol": "LUND-B.ST",
-  "date": {
-    "$date": "2016-02-03T00:00:00Z"
-  },
+  "date": "2016-02-03",
   "shares": 55,
   "amount": 2366.48,
   "grossAmount": 22111.68,
@@ -2215,9 +2023,7 @@
   "type": "Buy",
   "company": "\"Swatch \"",
   "symbol": "UHRN.SW",
-  "date": {
-    "$date": "2015-01-15T00:00:00Z"
-  },
+  "date": "2015-01-15",
   "shares": 27,
   "amount": 2000.61,
   "grossAmount": 2056.63,
@@ -2238,9 +2044,7 @@
   "type": "Sell",
   "company": "\"Swatch \"",
   "symbol": "UHRN.SW",
-  "date": {
-    "$date": "2016-01-26T00:00:00Z"
-  },
+  "date": "2016-01-26",
   "shares": 27,
   "amount": 1573.54,
   "grossAmount": 1732.15,
@@ -2261,9 +2065,7 @@
   "type": "Buy",
   "company": "\"Melco International Development \"",
   "symbol": "0200.HK",
-  "date": {
-    "$date": "2015-01-22T00:00:00Z"
-  },
+  "date": "2015-01-22",
   "shares": 2000,
   "amount": 3420.6,
   "grossAmount": 30810.71,
@@ -2284,9 +2086,7 @@
   "type": "Sell",
   "company": "\"Melco International Development \"",
   "symbol": "0200.HK",
-  "date": {
-    "$date": "2016-03-22T00:00:00Z"
-  },
+  "date": "2016-03-22",
   "shares": 2000,
   "amount": 2256.39,
   "grossAmount": 19617.51,
@@ -2307,9 +2107,7 @@
   "type": "Buy",
   "company": "Sofina",
   "symbol": "SOF.BR",
-  "date": {
-    "$date": "2015-03-23T00:00:00Z"
-  },
+  "date": "2015-03-23",
   "shares": 20,
   "amount": 1937,
   "grossAmount": 0,
@@ -2330,9 +2128,7 @@
   "type": "Sell",
   "company": "Sofina",
   "symbol": "SOF.BR",
-  "date": {
-    "$date": "2016-03-21T00:00:00Z"
-  },
+  "date": "2016-03-21",
   "shares": 20,
   "amount": 2012.6,
   "grossAmount": 0,
@@ -2353,9 +2149,7 @@
   "type": "Buy",
   "company": "O'Reilly",
   "symbol": "ORLY",
-  "date": {
-    "$date": "2015-08-20T00:00:00Z"
-  },
+  "date": "2015-08-20",
   "shares": 9,
   "amount": 2037.87,
   "grossAmount": 2278.95,
@@ -2376,9 +2170,7 @@
   "type": "Buy",
   "company": "O'Reilly",
   "symbol": "ORLY",
-  "date": {
-    "$date": "2017-02-02T00:00:00Z"
-  },
+  "date": "2017-02-02",
   "shares": 7,
   "amount": 1669.53,
   "grossAmount": 1801.42,
@@ -2399,9 +2191,7 @@
   "type": "Buy",
   "company": "O'Reilly",
   "symbol": "ORLY",
-  "date": {
-    "$date": "2017-07-05T00:00:00Z"
-  },
+  "date": "2017-07-05",
   "shares": 12,
   "amount": 1891.26,
   "grossAmount": 2142.61,
@@ -2422,9 +2212,7 @@
   "type": "Sell",
   "company": "O'Reilly",
   "symbol": "ORLY",
-  "date": {
-    "$date": "2019-02-08T00:00:00Z"
-  },
+  "date": "2019-02-08",
   "shares": 14,
   "amount": 4091,
   "grossAmount": 4641.24,
@@ -2445,9 +2233,7 @@
   "type": "Sell",
   "company": "O'Reilly",
   "symbol": "ORLY",
-  "date": {
-    "$date": "2019-07-23T00:00:00Z"
-  },
+  "date": "2019-07-23",
   "shares": 14,
   "amount": 4570.25,
   "grossAmount": 5106.34,
@@ -2468,9 +2254,7 @@
   "type": "Buy",
   "company": "Berkshire Hathaway",
   "symbol": "BRK-B",
-  "date": {
-    "$date": "2015-08-20T00:00:00Z"
-  },
+  "date": "2015-08-20",
   "shares": 16,
   "amount": 1984.96,
   "grossAmount": 2219.78,
@@ -2491,9 +2275,7 @@
   "type": "Buy",
   "company": "Berkshire Hathaway",
   "symbol": "BRK-B",
-  "date": {
-    "$date": "2016-02-01T00:00:00Z"
-  },
+  "date": "2016-02-01",
   "shares": 17,
   "amount": 2011.14,
   "grossAmount": 2196.16,
@@ -2514,9 +2296,7 @@
   "type": "Sell",
   "company": "Berkshire Hathaway",
   "symbol": "BRK-B",
-  "date": {
-    "$date": "2019-12-04T00:00:00Z"
-  },
+  "date": "2019-12-04",
   "shares": 33,
   "amount": 5779.71,
   "grossAmount": 6404.5,
@@ -2537,9 +2317,7 @@
   "type": "Buy",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2015-06-05T00:00:00Z"
-  },
+  "date": "2015-06-05",
   "shares": 24,
   "amount": 2003.52,
   "grossAmount": 2247.55,
@@ -2560,9 +2338,7 @@
   "type": "Buy",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2015-06-05T00:00:00Z"
-  },
+  "date": "2015-06-05",
   "shares": 68,
   "amount": 2014.5,
   "grossAmount": 2259.87,
@@ -2583,9 +2359,7 @@
   "type": "Buy",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2016-02-03T00:00:00Z"
-  },
+  "date": "2016-02-03",
   "shares": 19,
   "amount": 1482.78,
   "grossAmount": 1619.05,
@@ -2606,9 +2380,7 @@
   "type": "Buy",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2017-04-11T00:00:00Z"
-  },
+  "date": "2017-04-11",
   "shares": 42,
   "amount": 1514.13,
   "grossAmount": 1607.4,
@@ -2629,9 +2401,7 @@
   "type": "Buy",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2017-09-22T00:00:00Z"
-  },
+  "date": "2017-09-22",
   "shares": 50,
   "amount": 1525.4,
   "grossAmount": 1815.99,
@@ -2652,9 +2422,7 @@
   "type": "Sell",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2019-01-29T00:00:00Z"
-  },
+  "date": "2019-01-29",
   "shares": 160,
   "amount": 6308.57,
   "grossAmount": 7205.65,
@@ -2675,9 +2443,7 @@
   "type": "Buy",
   "company": "\"City Developments \"",
   "symbol": "C09.SI",
-  "date": {
-    "$date": "2015-05-04T00:00:00Z"
-  },
+  "date": "2015-05-04",
   "shares": 420,
   "amount": 3032.57,
   "grossAmount": 4506.7,
@@ -2698,9 +2464,7 @@
   "type": "Sell",
   "company": "\"City Developments \"",
   "symbol": "C09.SI",
-  "date": {
-    "$date": "2016-06-10T00:00:00Z"
-  },
+  "date": "2016-06-10",
   "shares": 420,
   "amount": 2359.28,
   "grossAmount": 3611.35,
@@ -2721,9 +2485,7 @@
   "type": "Buy",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2015-04-21T00:00:00Z"
-  },
+  "date": "2015-04-21",
   "shares": 130.5,
   "amount": 3023.64,
   "grossAmount": 3235.29,
@@ -2744,9 +2506,7 @@
   "type": "Buy",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2017-01-05T00:00:00Z"
-  },
+  "date": "2017-01-05",
   "shares": 70.5,
   "amount": 1500.36,
   "grossAmount": 1575.53,
@@ -2767,9 +2527,7 @@
   "type": "Buy",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2016-01-14T00:00:00Z"
-  },
+  "date": "2016-01-14",
   "shares": 87,
   "amount": 1509.86,
   "grossAmount": 1644.69,
@@ -2790,9 +2548,7 @@
   "type": "Buy",
   "company": "CarMax",
   "symbol": "KMX",
-  "date": {
-    "$date": "2016-01-14T00:00:00Z"
-  },
+  "date": "2016-01-14",
   "shares": 48,
   "amount": 2023.2,
   "grossAmount": 2203.87,
@@ -2813,9 +2569,7 @@
   "type": "Buy",
   "company": "CarMax",
   "symbol": "KMX",
-  "date": {
-    "$date": "2016-02-03T00:00:00Z"
-  },
+  "date": "2016-02-03",
   "shares": 39,
   "amount": 1500.48,
   "grossAmount": 1638.37,
@@ -2836,9 +2590,7 @@
   "type": "Sell",
   "company": "CarMax",
   "symbol": "KMX",
-  "date": {
-    "$date": "2019-07-31T00:00:00Z"
-  },
+  "date": "2019-07-31",
   "shares": 87,
   "amount": 5914.14,
   "grossAmount": 6594.86,
@@ -2859,9 +2611,7 @@
   "type": "Buy",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2012-06-05T00:00:00Z"
-  },
+  "date": "2012-06-05",
   "shares": 220,
   "amount": 2003.76,
   "grossAmount": 19322.26,
@@ -2882,9 +2632,7 @@
   "type": "Buy",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2016-01-27T00:00:00Z"
-  },
+  "date": "2016-01-27",
   "shares": 136,
   "amount": 1522.9,
   "grossAmount": 12868.2,
@@ -2905,9 +2653,7 @@
   "type": "Sell",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2017-08-17T00:00:00Z"
-  },
+  "date": "2017-08-17",
   "shares": 356,
   "amount": 3773.96,
   "grossAmount": 34568.34,
@@ -2928,9 +2674,7 @@
   "type": "Buy",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2016-02-11T00:00:00Z"
-  },
+  "date": "2016-02-11",
   "shares": 105,
   "amount": 2018.03,
   "grossAmount": 2289.86,
@@ -2951,9 +2695,7 @@
   "type": "Buy",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2019-07-08T00:00:00Z"
-  },
+  "date": "2019-07-08",
   "shares": 55,
   "amount": 1996.2,
   "grossAmount": 2238.74,
@@ -2974,9 +2716,7 @@
   "type": "Buy",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2016-06-27T00:00:00Z"
-  },
+  "date": "2016-06-27",
   "shares": 68,
   "amount": 1518.48,
   "grossAmount": 1680.35,
@@ -2997,9 +2737,7 @@
   "type": "Buy",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2016-03-29T00:00:00Z"
-  },
+  "date": "2016-03-29",
   "shares": 22,
   "amount": 1992.98,
   "grossAmount": 2222.97,
@@ -3020,9 +2758,7 @@
   "type": "Buy",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2020-03-04T00:00:00Z"
-  },
+  "date": "2020-03-04",
   "shares": 15,
   "amount": 505.23,
   "grossAmount": 561.66,
@@ -3043,9 +2779,7 @@
   "type": "Buy",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2016-09-09T00:00:00Z"
-  },
+  "date": "2016-09-09",
   "shares": 15,
   "amount": 1510.05,
   "grossAmount": 1705.75,
@@ -3066,9 +2800,7 @@
   "type": "Buy",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2018-01-11T00:00:00Z"
-  },
+  "date": "2018-01-11",
   "shares": 13,
   "amount": 1478.9,
   "grossAmount": 1777.19,
@@ -3089,9 +2821,7 @@
   "type": "Buy",
   "company": "Ametek",
   "symbol": "AME",
-  "date": {
-    "$date": "2016-05-13T00:00:00Z"
-  },
+  "date": "2016-05-13",
   "shares": 48,
   "amount": 1994.56,
   "grossAmount": 2263.43,
@@ -3112,9 +2842,7 @@
   "type": "Buy",
   "company": "Ametek",
   "symbol": "AME",
-  "date": {
-    "$date": "2016-11-09T00:00:00Z"
-  },
+  "date": "2016-11-09",
   "shares": 36,
   "amount": 1502.68,
   "grossAmount": 1658.66,
@@ -3135,9 +2863,7 @@
   "type": "Sell",
   "company": "Ametek",
   "symbol": "AME",
-  "date": {
-    "$date": "2017-09-12T00:00:00Z"
-  },
+  "date": "2017-09-12",
   "shares": 84,
   "amount": 4232.46,
   "grossAmount": 5050.59,
@@ -3158,9 +2884,7 @@
   "type": "Buy",
   "company": "Fuchs Petrolub",
   "symbol": "FPE.DE",
-  "date": {
-    "$date": "2018-10-10T00:00:00Z"
-  },
+  "date": "2018-10-10",
   "shares": 38,
   "amount": 1515.37,
   "grossAmount": 0,
@@ -3181,9 +2905,7 @@
   "type": "Buy",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2018-02-15T00:00:00Z"
-  },
+  "date": "2018-02-15",
   "shares": 23,
   "amount": 1512.26,
   "grossAmount": 1741.97,
@@ -3204,9 +2926,7 @@
   "type": "Buy",
   "company": "Fuchs Petrolub",
   "symbol": "FPE.DE",
-  "date": {
-    "$date": "2016-06-09T00:00:00Z"
-  },
+  "date": "2016-06-09",
   "shares": 61,
   "amount": 1997.22,
   "grossAmount": 0,
@@ -3227,9 +2947,7 @@
   "type": "Buy",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2016-10-25T00:00:00Z"
-  },
+  "date": "2016-10-25",
   "shares": 23,
   "amount": 1574.34,
   "grossAmount": 1703.59,
@@ -3250,9 +2968,7 @@
   "type": "Buy",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2011-09-06T00:00:00Z"
-  },
+  "date": "2011-09-06",
   "shares": 48,
   "amount": 1988.41,
   "grossAmount": 2393.25,
@@ -3273,9 +2989,7 @@
   "type": "Sell",
   "company": "Fuchs Petrolub",
   "symbol": "FPE.DE",
-  "date": {
-    "$date": "2019-05-21T00:00:00Z"
-  },
+  "date": "2019-05-21",
   "shares": 99,
   "amount": 3294.27,
   "grossAmount": 0,
@@ -3296,9 +3010,7 @@
   "type": "Buy",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2011-11-25T00:00:00Z"
-  },
+  "date": "2011-11-25",
   "shares": 18,
   "amount": 1980.25,
   "grossAmount": 2426.4,
@@ -3319,9 +3031,7 @@
   "type": "Buy",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2016-08-19T00:00:00Z"
-  },
+  "date": "2016-08-19",
   "shares": 7,
   "amount": 1574.34,
   "grossAmount": 1708.63,
@@ -3342,9 +3052,7 @@
   "type": "Sell",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2017-08-17T00:00:00Z"
-  },
+  "date": "2017-08-17",
   "shares": 25,
   "amount": 4882.97,
   "grossAmount": 5569.52,
@@ -3365,9 +3073,7 @@
   "type": "Buy",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2018-08-15T00:00:00Z"
-  },
+  "date": "2018-08-15",
   "shares": 15,
   "amount": 3168.79,
   "grossAmount": 3577.25,
@@ -3388,9 +3094,7 @@
   "type": "Buy",
   "company": "Novartis",
   "symbol": "NOVN.SW",
-  "date": {
-    "$date": "2011-08-09T00:00:00Z"
-  },
+  "date": "2011-08-09",
   "shares": 53,
   "amount": 2028.41,
   "grossAmount": 2148.9,
@@ -3411,9 +3115,7 @@
   "type": "Sell",
   "company": "Novartis",
   "symbol": "NOVN.SW",
-  "date": {
-    "$date": "2016-08-19T00:00:00Z"
-  },
+  "date": "2016-08-19",
   "shares": 53,
   "amount": 3304.71,
   "grossAmount": 3586.6,
@@ -3434,9 +3136,7 @@
   "type": "Buy",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2016-06-24T00:00:00Z"
-  },
+  "date": "2016-06-24",
   "shares": 89,
   "amount": 1999.14,
   "grossAmount": 161430.55,
@@ -3457,9 +3157,7 @@
   "type": "Buy",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2011-08-09T00:00:00Z"
-  },
+  "date": "2011-08-09",
   "shares": 150,
   "amount": 1997.25,
   "grossAmount": 174379.9,
@@ -3480,9 +3178,7 @@
   "type": "Sell",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2017-01-10T00:00:00Z"
-  },
+  "date": "2017-01-10",
   "shares": 41,
   "amount": 3071.94,
   "grossAmount": 3230.45,
@@ -3503,9 +3199,7 @@
   "type": "Buy",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2011-09-02T00:00:00Z"
-  },
+  "date": "2011-09-02",
   "shares": 41,
   "amount": 1989.63,
   "grossAmount": 2836.22,
@@ -3526,9 +3220,7 @@
   "type": "Buy",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2011-02-01T00:00:00Z"
-  },
+  "date": "2011-02-01",
   "shares": 46,
   "amount": 2015.64,
   "grossAmount": 2772.51,
@@ -3549,9 +3241,7 @@
   "type": "Buy",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2019-07-16T00:00:00Z"
-  },
+  "date": "2019-07-16",
   "shares": 15,
   "amount": 1788.65,
   "grossAmount": 2015.63,
@@ -3572,9 +3262,7 @@
   "type": "Sell",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2015-01-23T00:00:00Z"
-  },
+  "date": "2015-01-23",
   "shares": 11,
   "amount": 998.69,
   "grossAmount": 1118.33,
@@ -3595,9 +3283,7 @@
   "type": "Buy",
   "company": "ALPHABET INC.CL C DL-,001",
   "symbol": "GOOG",
-  "date": {
-    "$date": "2016-07-13T00:00:00Z"
-  },
+  "date": "2016-07-13",
   "shares": 4,
   "amount": 2610.3,
   "grossAmount": 2895.34,
@@ -3618,9 +3304,7 @@
   "type": "Buy",
   "company": "ALPHABET INC.CL C DL-,001",
   "symbol": "GOOG",
-  "date": {
-    "$date": "2017-06-27T00:00:00Z"
-  },
+  "date": "2017-06-27",
   "shares": 2,
   "amount": 1672.7,
   "grossAmount": 1871.25,
@@ -3641,9 +3325,7 @@
   "type": "Buy",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2016-09-16T00:00:00Z"
-  },
+  "date": "2016-09-16",
   "shares": 42,
   "amount": 1491.79,
   "grossAmount": 1674.68,
@@ -3664,9 +3346,7 @@
   "type": "Buy",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2016-08-03T00:00:00Z"
-  },
+  "date": "2016-08-03",
   "shares": 55,
   "amount": 2011.68,
   "grossAmount": 2251.67,
@@ -3687,9 +3367,7 @@
   "type": "Buy",
   "company": "ALPHABET INC.CL C DL-,001",
   "symbol": "GOOG",
-  "date": {
-    "$date": "2019-06-03T00:00:00Z"
-  },
+  "date": "2019-06-03",
   "shares": 2,
   "amount": 1855.31,
   "grossAmount": 2068.86,
@@ -3710,9 +3388,7 @@
   "type": "Buy",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2018-04-04T00:00:00Z"
-  },
+  "date": "2018-04-04",
   "shares": 42,
   "amount": 1519.8,
   "grossAmount": 1870.57,
@@ -3733,9 +3409,7 @@
   "type": "Sell",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2020-04-20T00:00:00Z"
-  },
+  "date": "2020-04-20",
   "shares": 139,
   "amount": 6920.81,
   "grossAmount": 7515.73,
@@ -3756,9 +3430,7 @@
   "type": "Buy",
   "company": "Regeneron",
   "symbol": "REGN",
-  "date": {
-    "$date": "2017-01-06T00:00:00Z"
-  },
+  "date": "2017-01-06",
   "shares": 6,
   "amount": 2036.4,
   "grossAmount": 2138.42,
@@ -3779,9 +3451,7 @@
   "type": "Buy",
   "company": "Regeneron",
   "symbol": "REGN",
-  "date": {
-    "$date": "2017-04-18T00:00:00Z"
-  },
+  "date": "2017-04-18",
   "shares": 4,
   "amount": 1386.6,
   "grossAmount": 1473.96,
@@ -3802,9 +3472,7 @@
   "type": "Buy",
   "company": "Regeneron",
   "symbol": "REGN",
-  "date": {
-    "$date": "2018-02-06T00:00:00Z"
-  },
+  "date": "2018-02-06",
   "shares": 6,
   "amount": 1594.2,
   "grossAmount": 1983.18,
@@ -3825,9 +3493,7 @@
   "type": "Sell",
   "company": "Regeneron",
   "symbol": "REGN",
-  "date": {
-    "$date": "2018-08-15T00:00:00Z"
-  },
+  "date": "2018-08-15",
   "shares": 16,
   "amount": 5154.71,
   "grossAmount": 5835.65,
@@ -3848,9 +3514,7 @@
   "type": "Buy",
   "company": "FACEBOOK INC.A DL-,000006",
   "symbol": "FB",
-  "date": {
-    "$date": "2017-01-10T00:00:00Z"
-  },
+  "date": "2017-01-10",
   "shares": 17,
   "amount": 2010.24,
   "grossAmount": 2124.22,
@@ -3871,9 +3535,7 @@
   "type": "Buy",
   "company": "FACEBOOK INC.A DL-,000006",
   "symbol": "FB",
-  "date": {
-    "$date": "2018-08-01T00:00:00Z"
-  },
+  "date": "2018-08-01",
   "shares": 10,
   "amount": 1505.44,
   "grossAmount": 1766.78,
@@ -3894,9 +3556,7 @@
   "type": "Buy",
   "company": "AMAZON.COM INC. DL-,01",
   "symbol": "AMZN",
-  "date": {
-    "$date": "2017-02-07T00:00:00Z"
-  },
+  "date": "2017-02-07",
   "shares": 3,
   "amount": 2299.95,
   "grossAmount": 2463.71,
@@ -3917,9 +3577,7 @@
   "type": "Buy",
   "company": "AMAZON.COM INC. DL-,01",
   "symbol": "AMZN",
-  "date": {
-    "$date": "2017-07-28T00:00:00Z"
-  },
+  "date": "2017-07-28",
   "shares": 2,
   "amount": 1734.54,
   "grossAmount": 2028.37,
@@ -3940,9 +3598,7 @@
   "type": "Buy",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2017-05-22T00:00:00Z"
-  },
+  "date": "2017-05-22",
   "shares": 18,
   "amount": 1976.99,
   "grossAmount": 2210.08,
@@ -3963,9 +3619,7 @@
   "type": "Buy",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2017-09-07T00:00:00Z"
-  },
+  "date": "2017-09-07",
   "shares": 14,
   "amount": 1560.46,
   "grossAmount": 1861.78,
@@ -3986,9 +3640,7 @@
   "type": "Buy",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2017-08-17T00:00:00Z"
-  },
+  "date": "2017-08-17",
   "shares": 51,
   "amount": 2013.54,
   "grossAmount": 14974.09,
@@ -4009,9 +3661,7 @@
   "type": "Buy",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2017-10-13T00:00:00Z"
-  },
+  "date": "2017-10-13",
   "shares": 38,
   "amount": 1533.28,
   "grossAmount": 11413.43,
@@ -4032,9 +3682,7 @@
   "type": "Buy",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2017-11-21T00:00:00Z"
-  },
+  "date": "2017-11-21",
   "shares": 25,
   "amount": 1490.6,
   "grossAmount": 132573.96,
@@ -4055,9 +3703,7 @@
   "type": "Buy",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2018-10-08T00:00:00Z"
-  },
+  "date": "2018-10-08",
   "shares": 40,
   "amount": 1503.64,
   "grossAmount": 11215.5,
@@ -4078,9 +3724,7 @@
   "type": "Buy",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2017-09-13T00:00:00Z"
-  },
+  "date": "2017-09-13",
   "shares": 36,
   "amount": 2025.47,
   "grossAmount": 182045.19,
@@ -4101,9 +3745,7 @@
   "type": "Buy",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2018-10-26T00:00:00Z"
-  },
+  "date": "2018-10-26",
   "shares": 29,
   "amount": 1473.06,
   "grossAmount": 130414.42,
@@ -4124,9 +3766,7 @@
   "type": "Sell",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2019-07-31T00:00:00Z"
-  },
+  "date": "2019-07-31",
   "shares": 90,
   "amount": 5419.25,
   "grossAmount": 496527.94,
@@ -4147,9 +3787,7 @@
   "type": "Buy",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2020-04-24T00:00:00Z"
-  },
+  "date": "2020-04-24",
   "shares": 10,
   "amount": 555.4,
   "grossAmount": 48430.8,
@@ -4170,9 +3808,7 @@
   "type": "Buy",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2020-05-04T00:00:00Z"
-  },
+  "date": "2020-05-04",
   "shares": 10,
   "amount": 522.2,
   "grossAmount": 45900,
@@ -4193,9 +3829,7 @@
   "type": "Sell",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2020-06-23T00:00:00Z"
-  },
+  "date": "2020-06-23",
   "shares": 20,
   "amount": 1210.4,
   "grossAmount": 109332.6,
@@ -4216,9 +3850,7 @@
   "type": "Buy",
   "company": "COLOPLAST NAM. B DK 1",
   "symbol": "COLO-B.CO",
-  "date": {
-    "$date": "2017-11-24T00:00:00Z"
-  },
+  "date": "2017-11-24",
   "shares": 30,
   "amount": 2035.53,
   "grossAmount": 15148.41,
@@ -4239,9 +3871,7 @@
   "type": "Buy",
   "company": "COLOPLAST NAM. B DK 1",
   "symbol": "COLO-B.CO",
-  "date": {
-    "$date": "2018-02-05T00:00:00Z"
-  },
+  "date": "2018-02-05",
   "shares": 23,
   "amount": 1534.34,
   "grossAmount": 11419.94,
@@ -4262,9 +3892,7 @@
   "type": "Buy",
   "company": "Fanuc",
   "symbol": "6954.T",
-  "date": {
-    "$date": "2018-07-06T00:00:00Z"
-  },
+  "date": "2018-07-06",
   "shares": 18,
   "amount": 2989.18,
   "grossAmount": 387188.48,
@@ -4285,9 +3913,7 @@
   "type": "Buy",
   "company": "Fanuc",
   "symbol": "6954.T",
-  "date": {
-    "$date": "2018-10-11T00:00:00Z"
-  },
+  "date": "2018-10-11",
   "shares": 11,
   "amount": 1603.89,
   "grossAmount": 208874.59,
@@ -4308,9 +3934,7 @@
   "type": "Sell",
   "company": "Fanuc",
   "symbol": "6954.T",
-  "date": {
-    "$date": "2019-08-01T00:00:00Z"
-  },
+  "date": "2019-08-01",
   "shares": 29,
   "amount": 4648.31,
   "grossAmount": 562631.44,
@@ -4331,9 +3955,7 @@
   "type": "Buy",
   "company": "ALIBABA GR.HLDG SP.ADR 8",
   "symbol": "BABA",
-  "date": {
-    "$date": "2018-07-17T00:00:00Z"
-  },
+  "date": "2018-07-17",
   "shares": 13,
   "amount": 2108.35,
   "grossAmount": 2470.99,
@@ -4354,9 +3976,7 @@
   "type": "Buy",
   "company": "ALIBABA GR.HLDG SP.ADR 8",
   "symbol": "BABA",
-  "date": {
-    "$date": "2018-08-24T00:00:00Z"
-  },
+  "date": "2018-08-24",
   "shares": 10,
   "amount": 1521.58,
   "grossAmount": 1761.84,
@@ -4377,9 +3997,7 @@
   "type": "Buy",
   "company": "ALIBABA GR.HLDG SP.ADR 8",
   "symbol": "BABA",
-  "date": {
-    "$date": "2018-09-11T00:00:00Z"
-  },
+  "date": "2018-09-11",
   "shares": 11,
   "amount": 1499.79,
   "grossAmount": 1737.06,
@@ -4400,9 +4018,7 @@
   "type": "Buy",
   "company": "OREAL (L') INH. EO 0,2",
   "symbol": "OR.PA",
-  "date": {
-    "$date": "2018-07-17T00:00:00Z"
-  },
+  "date": "2018-07-17",
   "shares": 14,
   "amount": 2952.62,
   "grossAmount": 0,
@@ -4423,9 +4039,7 @@
   "type": "Buy",
   "company": "OREAL (L') INH. EO 0,2",
   "symbol": "OR.PA",
-  "date": {
-    "$date": "2018-10-10T00:00:00Z"
-  },
+  "date": "2018-10-10",
   "shares": 8,
   "amount": 1550.55,
   "grossAmount": 0,
@@ -4446,9 +4060,7 @@
   "type": "Buy",
   "company": "Baidu",
   "symbol": "BIDU",
-  "date": {
-    "$date": "2018-07-19T00:00:00Z"
-  },
+  "date": "2018-07-19",
   "shares": 9,
   "amount": 2071.77,
   "grossAmount": 2400.77,
@@ -4469,9 +4081,7 @@
   "type": "Buy",
   "company": "Baidu",
   "symbol": "BIDU",
-  "date": {
-    "$date": "2018-08-01T00:00:00Z"
-  },
+  "date": "2018-08-01",
   "shares": 8,
   "amount": 1619.57,
   "grossAmount": 1900.73,
@@ -4492,9 +4102,7 @@
   "type": "Buy",
   "company": "Baidu",
   "symbol": "BIDU",
-  "date": {
-    "$date": "2018-10-08T00:00:00Z"
-  },
+  "date": "2018-10-08",
   "shares": 9,
   "amount": 1601.43,
   "grossAmount": 1842.61,
@@ -4515,9 +4123,7 @@
   "type": "Buy",
   "company": "ADOBE INC.",
   "symbol": "ADBE",
-  "date": {
-    "$date": "2018-07-25T00:00:00Z"
-  },
+  "date": "2018-07-25",
   "shares": 9,
   "amount": 2022.15,
   "grossAmount": 2367.13,
@@ -4538,9 +4144,7 @@
   "type": "Sell",
   "company": "Baidu",
   "symbol": "BIDU",
-  "date": {
-    "$date": "2019-06-07T00:00:00Z"
-  },
+  "date": "2019-06-07",
   "shares": 26,
   "amount": 2888.64,
   "grossAmount": 3254.34,
@@ -4561,9 +4165,7 @@
   "type": "Buy",
   "company": "ADOBE INC.",
   "symbol": "ADBE",
-  "date": {
-    "$date": "2019-01-10T00:00:00Z"
-  },
+  "date": "2019-01-10",
   "shares": 10,
   "amount": 2048.3,
   "grossAmount": 2346.33,
@@ -4584,9 +4186,7 @@
   "type": "Buy",
   "company": "ESSILORLUXO. INH. EO -,18",
   "symbol": "EL.PA",
-  "date": {
-    "$date": "2018-10-02T00:00:00Z"
-  },
+  "date": "2018-10-02",
   "shares": 16,
   "amount": 2064.16,
   "grossAmount": 0,
@@ -4607,9 +4207,7 @@
   "type": "Buy",
   "company": "ESSILORLUXO. INH. EO -,18",
   "symbol": "EL.PA",
-  "date": {
-    "$date": "2018-11-21T00:00:00Z"
-  },
+  "date": "2018-11-21",
   "shares": 14,
   "amount": 1551.25,
   "grossAmount": 0,
@@ -4630,9 +4228,7 @@
   "type": "Buy",
   "company": "ESSILORLUXO. INH. EO -,18",
   "symbol": "EL.PA",
-  "date": {
-    "$date": "2019-03-21T00:00:00Z"
-  },
+  "date": "2019-03-21",
   "shares": 15,
   "amount": 1496.26,
   "grossAmount": 0,
@@ -4653,9 +4249,7 @@
   "type": "Buy",
   "company": "LVMH EO 0,3",
   "symbol": "MC.PA",
-  "date": {
-    "$date": "2019-01-28T00:00:00Z"
-  },
+  "date": "2019-01-28",
   "shares": 10,
   "amount": 2607.64,
   "grossAmount": 0,
@@ -4676,9 +4270,7 @@
   "type": "Buy",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2019-02-04T00:00:00Z"
-  },
+  "date": "2019-02-04",
   "shares": 11,
   "amount": 2584.34,
   "grossAmount": 2964.5,
@@ -4699,9 +4291,7 @@
   "type": "Buy",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2019-03-01T00:00:00Z"
-  },
+  "date": "2019-03-01",
   "shares": 9,
   "amount": 1955.29,
   "grossAmount": 2232.16,
@@ -4722,9 +4312,7 @@
   "type": "Buy",
   "company": "DASSAULT SYS SA INH.EO0,5",
   "symbol": "DSY.PA",
-  "date": {
-    "$date": "2019-02-08T00:00:00Z"
-  },
+  "date": "2019-02-08",
   "shares": 20,
   "amount": 2551.83,
   "grossAmount": 0,
@@ -4745,9 +4333,7 @@
   "type": "Buy",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2019-04-15T00:00:00Z"
-  },
+  "date": "2019-04-15",
   "shares": 10,
   "amount": 2020.43,
   "grossAmount": 2287.33,
@@ -4768,9 +4354,7 @@
   "type": "Buy",
   "company": "ECOLAB INC. DL 1",
   "symbol": "ECL",
-  "date": {
-    "$date": "2019-02-08T00:00:00Z"
-  },
+  "date": "2019-02-08",
   "shares": 18,
   "amount": 2521.46,
   "grossAmount": 2860.6,
@@ -4791,9 +4375,7 @@
   "type": "Buy",
   "company": "INTUIT INC. DL-,01",
   "symbol": "INTU",
-  "date": {
-    "$date": "2019-02-08T00:00:00Z"
-  },
+  "date": "2019-02-08",
   "shares": 13,
   "amount": 2541.42,
   "grossAmount": 2883.24,
@@ -4814,9 +4396,7 @@
   "type": "Buy",
   "company": "INTUIT INC. DL-,01",
   "symbol": "INTU",
-  "date": {
-    "$date": "2019-05-03T00:00:00Z"
-  },
+  "date": "2019-05-03",
   "shares": 9,
   "amount": 1977.22,
   "grossAmount": 2205.59,
@@ -4837,9 +4417,7 @@
   "type": "Buy",
   "company": "NIKE INC. B",
   "symbol": "NKE",
-  "date": {
-    "$date": "2019-02-08T00:00:00Z"
-  },
+  "date": "2019-02-08",
   "shares": 34,
   "amount": 2481.86,
   "grossAmount": 2815.67,
@@ -4860,9 +4438,7 @@
   "type": "Buy",
   "company": "NIKE INC. B",
   "symbol": "NKE",
-  "date": {
-    "$date": "2019-04-02T00:00:00Z"
-  },
+  "date": "2019-04-02",
   "shares": 26,
   "amount": 1981.15,
   "grossAmount": 2226.02,
@@ -4883,9 +4459,7 @@
   "type": "Buy",
   "company": "AIA GROUP LTD",
   "symbol": "1299.HK",
-  "date": {
-    "$date": "2019-02-11T00:00:00Z"
-  },
+  "date": "2019-02-11",
   "shares": 300,
   "amount": 2528.19,
   "grossAmount": 22505.95,
@@ -4906,9 +4480,7 @@
   "type": "Buy",
   "company": "AIA GROUP LTD",
   "symbol": "1299.HK",
-  "date": {
-    "$date": "2019-08-14T00:00:00Z"
-  },
+  "date": "2019-08-14",
   "shares": 180,
   "amount": 1523.03,
   "grossAmount": 13411.35,
@@ -4929,9 +4501,7 @@
   "type": "Buy",
   "company": "AIA GROUP LTD",
   "symbol": "1299.HK",
-  "date": {
-    "$date": "2020-07-31T00:00:00Z"
-  },
+  "date": "2020-07-31",
   "shares": 130,
   "amount": 1001.52,
   "grossAmount": 9114.95,
@@ -4952,9 +4522,7 @@
   "type": "Buy",
   "company": "KEYENCE CORP.",
   "symbol": "6861.T",
-  "date": {
-    "$date": "2019-02-11T00:00:00Z"
-  },
+  "date": "2019-02-11",
   "shares": 10,
   "amount": 2481.88,
   "grossAmount": 309167.79,
@@ -4975,9 +4543,7 @@
   "type": "Buy",
   "company": "KEYENCE CORP.",
   "symbol": "6861.T",
-  "date": {
-    "$date": "2019-05-15T00:00:00Z"
-  },
+  "date": "2019-05-15",
   "shares": 8,
   "amount": 2191.2,
   "grossAmount": 269517.6,
@@ -4998,9 +4564,7 @@
   "type": "Buy",
   "company": "HDFC BANK LTD ADR/3 IR 10",
   "symbol": "HDB",
-  "date": {
-    "$date": "2019-02-19T00:00:00Z"
-  },
+  "date": "2019-02-19",
   "shares": 56,
   "amount": 2460.35,
   "grossAmount": 2787.08,
@@ -5021,9 +4585,7 @@
   "type": "Buy",
   "company": "HDFC BANK LTD ADR/3 IR 10",
   "symbol": "HDB",
-  "date": {
-    "$date": "2019-09-06T00:00:00Z"
-  },
+  "date": "2019-09-06",
   "shares": 32,
   "amount": 1541.74,
   "grossAmount": 1704.86,
@@ -5044,9 +4606,7 @@
   "type": "Buy",
   "company": "HDFC BANK LTD ADR/3 IR 10",
   "symbol": "HDB",
-  "date": {
-    "$date": "2020-01-21T00:00:00Z"
-  },
+  "date": "2020-01-21",
   "shares": 20,
   "amount": 1081,
   "grossAmount": 1198.29,
@@ -5067,9 +4627,7 @@
   "type": "Buy",
   "company": "HDFC BANK LTD ADR/3 IR 10",
   "symbol": "HDB",
-  "date": {
-    "$date": "2020-07-29T00:00:00Z"
-  },
+  "date": "2020-07-29",
   "shares": 25,
   "amount": 1025,
   "grossAmount": 1200.99,
@@ -5090,9 +4648,7 @@
   "type": "Buy",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2019-05-21T00:00:00Z"
-  },
+  "date": "2019-05-21",
   "shares": 15,
   "amount": 2535.41,
   "grossAmount": 2831.29,
@@ -5113,9 +4669,7 @@
   "type": "Buy",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2019-12-06T00:00:00Z"
-  },
+  "date": "2019-12-06",
   "shares": 5,
   "amount": 932,
   "grossAmount": 1033.96,
@@ -5136,9 +4690,7 @@
   "type": "Buy",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2019-12-18T00:00:00Z"
-  },
+  "date": "2019-12-18",
   "shares": 5,
   "amount": 914.8,
   "grossAmount": 1016.8,
@@ -5159,9 +4711,7 @@
   "type": "Buy",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2020-07-01T00:00:00Z"
-  },
+  "date": "2020-07-01",
   "shares": 7,
   "amount": 1036.98,
   "grossAmount": 1161.42,
@@ -5182,9 +4732,7 @@
   "type": "Sell",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2020-09-23T00:00:00Z"
-  },
+  "date": "2020-09-23",
   "shares": 32,
   "amount": 4545.28,
   "grossAmount": 5314.34,
@@ -5205,9 +4753,7 @@
   "type": "Buy",
   "company": "PAYPAL HDGS INC.DL-,0001",
   "symbol": "PYPL",
-  "date": {
-    "$date": "2019-08-28T00:00:00Z"
-  },
+  "date": "2019-08-28",
   "shares": 15,
   "amount": 1452.86,
   "grossAmount": 1613.26,
@@ -5228,9 +4774,7 @@
   "type": "Buy",
   "company": "PAYPAL HDGS INC.DL-,0001",
   "symbol": "PYPL",
-  "date": {
-    "$date": "2019-06-07T00:00:00Z"
-  },
+  "date": "2019-06-07",
   "shares": 25,
   "amount": 2520.17,
   "grossAmount": 2839.22,
@@ -5251,9 +4795,7 @@
   "type": "Buy",
   "company": "PAYPAL HDGS INC.DL-,0001",
   "symbol": "PYPL",
-  "date": {
-    "$date": "2019-10-02T00:00:00Z"
-  },
+  "date": "2019-10-02",
   "shares": 16,
   "amount": 1473.04,
   "grossAmount": 1609.3,
@@ -5274,9 +4816,7 @@
   "type": "Buy",
   "company": "PAYPAL HDGS INC.DL-,0001",
   "symbol": "PYPL",
-  "date": {
-    "$date": "2020-03-27T00:00:00Z"
-  },
+  "date": "2020-03-27",
   "shares": 6,
   "amount": 518.7,
   "grossAmount": 518.7,
@@ -5297,9 +4837,7 @@
   "type": "Buy",
   "company": "ZOETIS INC. CL.A DL -,01",
   "symbol": "ZTS",
-  "date": {
-    "$date": "2019-09-16T00:00:00Z"
-  },
+  "date": "2019-09-16",
   "shares": 23,
   "amount": 2536.61,
   "grossAmount": 2798.13,
@@ -5320,9 +4858,7 @@
   "type": "Buy",
   "company": "Blackbaud",
   "symbol": "BLKB",
-  "date": {
-    "$date": "2020-03-13T00:00:00Z"
-  },
+  "date": "2020-03-13",
   "shares": 11,
   "amount": 517,
   "grossAmount": 517,
@@ -5343,9 +4879,7 @@
   "type": "Buy",
   "company": "Blackbaud",
   "symbol": "BLKB",
-  "date": {
-    "$date": "2020-02-20T00:00:00Z"
-  },
+  "date": "2020-02-20",
   "shares": 7,
   "amount": 512,
   "grossAmount": 552.96,
@@ -5366,9 +4900,7 @@
   "type": "Sell",
   "company": "Blackbaud",
   "symbol": "BLKB",
-  "date": {
-    "$date": "2020-06-23T00:00:00Z"
-  },
+  "date": "2020-06-23",
   "shares": 26,
   "amount": 1365,
   "grossAmount": 1530.57,
@@ -5389,9 +4921,7 @@
   "type": "Buy",
   "company": "ZOETIS INC. CL.A DL -,01",
   "symbol": "ZTS",
-  "date": {
-    "$date": "2019-11-08T00:00:00Z"
-  },
+  "date": "2019-11-08",
   "shares": 5,
   "amount": 542.4,
   "grossAmount": 598.48,
@@ -5412,9 +4942,7 @@
   "type": "Buy",
   "company": "Blackbaud",
   "symbol": "BLKB",
-  "date": {
-    "$date": "2020-02-28T00:00:00Z"
-  },
+  "date": "2020-02-28",
   "shares": 8,
   "amount": 489,
   "grossAmount": 536.14,
@@ -5435,9 +4963,7 @@
   "type": "Dividend",
   "company": "ESTEE LAUDER COS A DL-,01",
   "symbol": "EL",
-  "date": {
-    "$date": "2019-09-16T00:00:00Z"
-  },
+  "date": "2019-09-16",
   "shares": 15,
   "amount": 4.31,
   "grossAmount": 0,
@@ -5457,9 +4983,7 @@
   "type": "Dividend",
   "company": "ESTEE LAUDER COS A DL-,01",
   "symbol": "EL",
-  "date": {
-    "$date": "2020-03-16T00:00:00Z"
-  },
+  "date": "2020-03-16",
   "shares": 24,
   "amount": 10.48,
   "grossAmount": 0,
@@ -5479,9 +5003,7 @@
   "type": "Dividend",
   "company": "ESTEE LAUDER COS A DL-,01",
   "symbol": "EL",
-  "date": {
-    "$date": "2019-12-16T00:00:00Z"
-  },
+  "date": "2019-12-16",
   "shares": 24,
   "amount": 7.62,
   "grossAmount": 0,
@@ -5501,9 +5023,7 @@
   "type": "Dividend",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2019-09-30T00:00:00Z"
-  },
+  "date": "2019-09-30",
   "shares": 18,
   "amount": 9.38,
   "grossAmount": 0,
@@ -5523,9 +5043,7 @@
   "type": "Dividend",
   "company": "ESTEE LAUDER COS A DL-,01",
   "symbol": "EL",
-  "date": {
-    "$date": "2020-09-15T00:00:00Z"
-  },
+  "date": "2020-09-15",
   "shares": 29,
   "amount": 11.71,
   "grossAmount": 0,
@@ -5545,9 +5063,7 @@
   "type": "Dividend",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2020-03-31T00:00:00Z"
-  },
+  "date": "2020-03-31",
   "shares": 27,
   "amount": 19.35,
   "grossAmount": 0,
@@ -5567,9 +5083,7 @@
   "type": "Dividend",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2019-12-31T00:00:00Z"
-  },
+  "date": "2019-12-31",
   "shares": 20,
   "amount": 10.4,
   "grossAmount": 0,
@@ -5589,9 +5103,7 @@
   "type": "Dividend",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2020-06-30T00:00:00Z"
-  },
+  "date": "2020-06-30",
   "shares": 27,
   "amount": 18.98,
   "grossAmount": 0,
@@ -5611,9 +5123,7 @@
   "type": "Dividend",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2020-09-30T00:00:00Z"
-  },
+  "date": "2020-09-30",
   "shares": 27,
   "amount": 18.29,
   "grossAmount": 0,
@@ -5633,9 +5143,7 @@
   "type": "Dividend",
   "company": "AUTOM. DATA PROC. DL -,10",
   "symbol": "ADP",
-  "date": {
-    "$date": "2019-10-01T00:00:00Z"
-  },
+  "date": "2019-10-01",
   "shares": 26,
   "amount": 13.9,
   "grossAmount": 0,
@@ -5655,9 +5163,7 @@
   "type": "Dividend",
   "company": "AUTOM. DATA PROC. DL -,10",
   "symbol": "ADP",
-  "date": {
-    "$date": "2020-01-01T00:00:00Z"
-  },
+  "date": "2020-01-01",
   "shares": 26,
   "amount": 15.66,
   "grossAmount": 0,
@@ -5677,9 +5183,7 @@
   "type": "Dividend",
   "company": "AUTOM. DATA PROC. DL -,10",
   "symbol": "ADP",
-  "date": {
-    "$date": "2020-04-01T00:00:00Z"
-  },
+  "date": "2020-04-01",
   "shares": 26,
   "amount": 21.44,
   "grossAmount": 0,
@@ -5699,9 +5203,7 @@
   "type": "Dividend",
   "company": "AUTOM. DATA PROC. DL -,10",
   "symbol": "ADP",
-  "date": {
-    "$date": "2020-10-01T00:00:00Z"
-  },
+  "date": "2020-10-01",
   "shares": 43,
   "amount": 33.46,
   "grossAmount": 0,
@@ -5721,9 +5223,7 @@
   "type": "Dividend",
   "company": "AUTOM. DATA PROC. DL -,10",
   "symbol": "ADP",
-  "date": {
-    "$date": "2020-07-01T00:00:00Z"
-  },
+  "date": "2020-07-01",
   "shares": 34,
   "amount": 27.4,
   "grossAmount": 0,
@@ -5743,9 +5243,7 @@
   "type": "Dividend",
   "company": "ASML HOLDING EO -,09",
   "symbol": "ASML.AS",
-  "date": {
-    "$date": "2019-11-15T00:00:00Z"
-  },
+  "date": "2019-11-15",
   "shares": 20,
   "amount": 15.51,
   "grossAmount": 0,
@@ -5765,9 +5263,7 @@
   "type": "Dividend",
   "company": "ASML HOLDING EO -,09",
   "symbol": "ASML.AS",
-  "date": {
-    "$date": "2020-05-06T00:00:00Z"
-  },
+  "date": "2020-05-06",
   "shares": 20,
   "amount": 27,
   "grossAmount": 0,
@@ -5787,9 +5283,7 @@
   "type": "Dividend",
   "company": "Inditex",
   "symbol": "ITX.MC",
-  "date": {
-    "$date": "2019-11-04T00:00:00Z"
-  },
+  "date": "2019-11-04",
   "shares": 90,
   "amount": 27.66,
   "grossAmount": 0,
@@ -5809,9 +5303,7 @@
   "type": "Dividend",
   "company": "EQUINIX INC. DL-,001",
   "symbol": "EQIX",
-  "date": {
-    "$date": "2019-12-11T00:00:00Z"
-  },
+  "date": "2019-12-11",
   "shares": 2,
   "amount": 3.31,
   "grossAmount": 0,
@@ -5831,9 +5323,7 @@
   "type": "Dividend",
   "company": "EQUINIX INC. DL-,001",
   "symbol": "EQIX",
-  "date": {
-    "$date": "2020-03-18T00:00:00Z"
-  },
+  "date": "2020-03-18",
   "shares": 2,
   "amount": 4.84,
   "grossAmount": 0,
@@ -5853,9 +5343,7 @@
   "type": "Dividend",
   "company": "EQUINIX INC. DL-,001",
   "symbol": "EQIX",
-  "date": {
-    "$date": "2020-09-23T00:00:00Z"
-  },
+  "date": "2020-09-23",
   "shares": 2,
   "amount": 4.51,
   "grossAmount": 0,
@@ -5875,9 +5363,7 @@
   "type": "Dividend",
   "company": "EQUINIX INC. DL-,001",
   "symbol": "EQIX",
-  "date": {
-    "$date": "2020-06-17T00:00:00Z"
-  },
+  "date": "2020-06-17",
   "shares": 2,
   "amount": 4.72,
   "grossAmount": 0,
@@ -5897,9 +5383,7 @@
   "type": "Dividend",
   "company": "MOODY'S CORP DL-,01",
   "symbol": "MCO",
-  "date": {
-    "$date": "2019-12-12T00:00:00Z"
-  },
+  "date": "2019-12-12",
   "shares": 5,
   "amount": 1.68,
   "grossAmount": 0,
@@ -5919,9 +5403,7 @@
   "type": "Dividend",
   "company": "MOODY'S CORP DL-,01",
   "symbol": "MCO",
-  "date": {
-    "$date": "2020-03-18T00:00:00Z"
-  },
+  "date": "2020-03-18",
   "shares": 5,
   "amount": 2.5,
   "grossAmount": 0,
@@ -5941,9 +5423,7 @@
   "type": "Dividend",
   "company": "LINDE PLC EO 0,001",
   "symbol": "LIN.DE",
-  "date": {
-    "$date": "2020-03-20T00:00:00Z"
-  },
+  "date": "2020-03-20",
   "shares": 15,
   "amount": 13.25,
   "grossAmount": 0,
@@ -5963,9 +5443,7 @@
   "type": "Dividend",
   "company": "LINDE PLC EO 0,001",
   "symbol": "LIN.DE",
-  "date": {
-    "$date": "2019-12-17T00:00:00Z"
-  },
+  "date": "2019-12-17",
   "shares": 15,
   "amount": 8.48,
   "grossAmount": 0,
@@ -5985,9 +5463,7 @@
   "type": "Dividend",
   "company": "MOODY'S CORP DL-,01",
   "symbol": "MCO",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 13,
   "amount": 6.44,
   "grossAmount": 0,
@@ -6007,9 +5483,7 @@
   "type": "Dividend",
   "company": "LINDE PLC EO 0,001",
   "symbol": "LIN.DE",
-  "date": {
-    "$date": "2020-06-17T00:00:00Z"
-  },
+  "date": "2020-06-17",
   "shares": 19,
   "amount": 16.23,
   "grossAmount": 0,
@@ -6029,9 +5503,7 @@
   "type": "Dividend",
   "company": "LINDE PLC EO 0,001",
   "symbol": "LIN.DE",
-  "date": {
-    "$date": "2020-09-18T00:00:00Z"
-  },
+  "date": "2020-09-18",
   "shares": 19,
   "amount": 15.47,
   "grossAmount": 0,
@@ -6051,9 +5523,7 @@
   "type": "Dividend",
   "company": "EXPERIAN PLC DL -,10",
   "symbol": "EXPN.L",
-  "date": {
-    "$date": "2020-01-31T00:00:00Z"
-  },
+  "date": "2020-01-31",
   "shares": 145,
   "amount": 18.94,
   "grossAmount": 0,
@@ -6073,9 +5543,7 @@
   "type": "Dividend",
   "company": "Bio-Techne",
   "symbol": "TECH",
-  "date": {
-    "$date": "2020-05-22T00:00:00Z"
-  },
+  "date": "2020-05-22",
   "shares": 7,
   "amount": 2.05,
   "grossAmount": 0,
@@ -6095,9 +5563,7 @@
   "type": "Dividend",
   "company": "Bio-Techne",
   "symbol": "TECH",
-  "date": {
-    "$date": "2020-02-28T00:00:00Z"
-  },
+  "date": "2020-02-28",
   "shares": 3,
   "amount": 0.65,
   "grossAmount": 0,
@@ -6117,9 +5583,7 @@
   "type": "Dividend",
   "company": "EXPERIAN PLC DL -,10",
   "symbol": "EXPN.L",
-  "date": {
-    "$date": "2020-07-24T00:00:00Z"
-  },
+  "date": "2020-07-24",
   "shares": 168,
   "amount": 48.27,
   "grossAmount": 0,
@@ -6139,9 +5603,7 @@
   "type": "Dividend",
   "company": "PARTNERS GR.HLDG SF -,01",
   "symbol": "PGHN.SW",
-  "date": {
-    "$date": "2020-05-19T00:00:00Z"
-  },
+  "date": "2020-05-19",
   "shares": 4,
   "amount": 95.6,
   "grossAmount": 0,
@@ -6161,9 +5623,7 @@
   "type": "Dividend",
   "company": "SAP SE O.N.",
   "symbol": "SAP.DE",
-  "date": {
-    "$date": "2020-05-26T00:00:00Z"
-  },
+  "date": "2020-05-26",
   "shares": 44,
   "amount": 69.52,
   "grossAmount": 0,
@@ -6183,9 +5643,7 @@
   "type": "Dividend",
   "company": "VISA INC. CL. A DL -,0001",
   "symbol": "V",
-  "date": {
-    "$date": "2020-06-02T00:00:00Z"
-  },
+  "date": "2020-06-02",
   "shares": 6,
   "amount": 1.62,
   "grossAmount": 0,
@@ -6205,9 +5663,7 @@
   "type": "Dividend",
   "company": "TENCENT HLDGS HD-,00002",
   "symbol": "0700.HK",
-  "date": {
-    "$date": "2020-05-29T00:00:00Z"
-  },
+  "date": "2020-05-29",
   "shares": 100,
   "amount": 13.85,
   "grossAmount": 0,
@@ -6227,9 +5683,7 @@
   "type": "Dividend",
   "company": "VISA INC. CL. A DL -,0001",
   "symbol": "V",
-  "date": {
-    "$date": "2020-09-01T00:00:00Z"
-  },
+  "date": "2020-09-01",
   "shares": 12,
   "amount": 3.02,
   "grossAmount": 0,
@@ -6249,9 +5703,7 @@
   "type": "Dividend",
   "company": "VERISK ANALYTICS DL-001",
   "symbol": "VRSK",
-  "date": {
-    "$date": "2020-06-30T00:00:00Z"
-  },
+  "date": "2020-06-30",
   "shares": 7,
   "amount": 1.68,
   "grossAmount": 0,
@@ -6271,9 +5723,7 @@
   "type": "Dividend",
   "company": "KERING S.A. INH. EO 4",
   "symbol": "KER.PA",
-  "date": {
-    "$date": "2020-06-25T00:00:00Z"
-  },
+  "date": "2020-06-25",
   "shares": 5,
   "amount": 22.5,
   "grossAmount": 0,
@@ -6293,9 +5743,7 @@
   "type": "Dividend",
   "company": "SARTOR.STED.B. EO-,20",
   "symbol": "DIM.PA",
-  "date": {
-    "$date": "2020-07-01T00:00:00Z"
-  },
+  "date": "2020-07-01",
   "shares": 8,
   "amount": 2.72,
   "grossAmount": 0,
@@ -6315,9 +5763,7 @@
   "type": "Dividend",
   "company": "HEICO CORP. DL-,01",
   "symbol": "HEI",
-  "date": {
-    "$date": "2020-07-15T00:00:00Z"
-  },
+  "date": "2020-07-15",
   "shares": 17,
   "amount": 1.2,
   "grossAmount": 0,
@@ -6337,9 +5783,7 @@
   "type": "Dividend",
   "company": "TAIWAN SEMICON.MANU.ADR/5",
   "symbol": "TSM",
-  "date": {
-    "$date": "2020-07-16T00:00:00Z"
-  },
+  "date": "2020-07-16",
   "shares": 21,
   "amount": 7.78,
   "grossAmount": 0,
@@ -6359,9 +5803,7 @@
   "type": "Dividend",
   "company": "VERISK ANALYTICS DL-001",
   "symbol": "VRSK",
-  "date": {
-    "$date": "2020-09-30T00:00:00Z"
-  },
+  "date": "2020-09-30",
   "shares": 14,
   "amount": 3.25,
   "grossAmount": 0,
@@ -6381,9 +5823,7 @@
   "type": "Dividend",
   "company": "ROPER TECHNOLOGIES DL-,01",
   "symbol": "ROP",
-  "date": {
-    "$date": "2020-07-22T00:00:00Z"
-  },
+  "date": "2020-07-22",
   "shares": 4,
   "amount": 1.79,
   "grossAmount": 0,
@@ -6403,9 +5843,7 @@
   "type": "Dividend",
   "company": "IHS MARKIT LTD DL -,01",
   "symbol": "INFO",
-  "date": {
-    "$date": "2020-08-14T00:00:00Z"
-  },
+  "date": "2020-08-14",
   "shares": 16,
   "amount": 2.31,
   "grossAmount": 0,
@@ -6425,9 +5863,7 @@
   "type": "Dividend",
   "company": "ABBOTT LABS",
   "symbol": "ABT",
-  "date": {
-    "$date": "2020-08-17T00:00:00Z"
-  },
+  "date": "2020-08-17",
   "shares": 14,
   "amount": 4.24,
   "grossAmount": 0,
@@ -6447,9 +5883,7 @@
   "type": "Dividend",
   "company": "MARKETAXESS HLDGS DL-,001",
   "symbol": "MKTX",
-  "date": {
-    "$date": "2020-08-19T00:00:00Z"
-  },
+  "date": "2020-08-19",
   "shares": 3,
   "amount": 1.52,
   "grossAmount": 0,
@@ -6469,9 +5903,7 @@
   "type": "Dividend",
   "company": "COGNEX CORP. DL-,002",
   "symbol": "CGNX",
-  "date": {
-    "$date": "2020-08-28T00:00:00Z"
-  },
+  "date": "2020-08-28",
   "shares": 20,
   "amount": 0.93,
   "grossAmount": 0,
@@ -6491,9 +5923,7 @@
   "type": "Dividend",
   "company": "STARBUCKS CORP.",
   "symbol": "SBUX",
-  "date": {
-    "$date": "2020-08-21T00:00:00Z"
-  },
+  "date": "2020-08-21",
   "shares": 15,
   "amount": 5.14,
   "grossAmount": 0,
@@ -6513,9 +5943,7 @@
   "type": "Dividend",
   "company": "MSCI INC. A DL-,01",
   "symbol": "MSCI",
-  "date": {
-    "$date": "2020-08-31T00:00:00Z"
-  },
+  "date": "2020-08-31",
   "shares": 4,
   "amount": 2.64,
   "grossAmount": 0,
@@ -6535,9 +5963,7 @@
   "type": "Dividend",
   "company": "NVIDIA CORP. DL-,001",
   "symbol": "NVDA",
-  "date": {
-    "$date": "2020-09-24T00:00:00Z"
-  },
+  "date": "2020-09-24",
   "shares": 3,
   "amount": 0.41,
   "grossAmount": 0,
@@ -6557,9 +5983,7 @@
   "type": "Dividend",
   "company": "FIDELITY NATL INF. SVCS",
   "symbol": "FIS",
-  "date": {
-    "$date": "2020-09-25T00:00:00Z"
-  },
+  "date": "2020-09-25",
   "shares": 8,
   "amount": 2.39,
   "grossAmount": 0,
@@ -6579,9 +6003,7 @@
   "type": "Dividend",
   "company": "JACK HENRY + ASS. DL -,01",
   "symbol": "JKHY",
-  "date": {
-    "$date": "2020-09-28T00:00:00Z"
-  },
+  "date": "2020-09-28",
   "shares": 17,
   "amount": 6.27,
   "grossAmount": 0,
@@ -6601,9 +6023,7 @@
   "type": "Dividend",
   "company": "Blackbaud",
   "symbol": "BLKB",
-  "date": {
-    "$date": "2020-03-13T00:00:00Z"
-  },
+  "date": "2020-03-13",
   "shares": 7,
   "amount": 0.74,
   "grossAmount": 0,
@@ -6623,9 +6043,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2011-03-15T00:00:00Z"
-  },
+  "date": "2011-03-15",
   "shares": 46,
   "amount": 13.16,
   "grossAmount": 0,
@@ -6645,9 +6063,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2011-03-16T00:00:00Z"
-  },
+  "date": "2011-03-16",
   "shares": 92,
   "amount": 14.14,
   "grossAmount": 0,
@@ -6667,9 +6083,7 @@
   "type": "Dividend",
   "company": "Munich Re",
   "symbol": "MUV2.DE",
-  "date": {
-    "$date": "2011-04-21T00:00:00Z"
-  },
+  "date": "2011-04-21",
   "shares": 20,
   "amount": 90.01,
   "grossAmount": 0,
@@ -6689,9 +6103,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2011-05-16T00:00:00Z"
-  },
+  "date": "2011-05-16",
   "shares": 46,
   "amount": 12.6,
   "grossAmount": 0,
@@ -6711,9 +6123,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2011-06-01T00:00:00Z"
-  },
+  "date": "2011-06-01",
   "shares": 147,
   "amount": 13.54,
   "grossAmount": 0,
@@ -6733,9 +6143,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2011-06-10T00:00:00Z"
-  },
+  "date": "2011-06-10",
   "shares": 70,
   "amount": 18.7,
   "grossAmount": 0,
@@ -6755,9 +6163,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2011-06-15T00:00:00Z"
-  },
+  "date": "2011-06-15",
   "shares": 92,
   "amount": 15.28,
   "grossAmount": 0,
@@ -6777,9 +6183,7 @@
   "type": "Dividend",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2011-05-26T00:00:00Z"
-  },
+  "date": "2011-05-26",
   "shares": 50,
   "amount": 26.86,
   "grossAmount": 0,
@@ -6799,9 +6203,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2011-06-14T00:00:00Z"
-  },
+  "date": "2011-06-14",
   "shares": 46,
   "amount": 13.36,
   "grossAmount": 0,
@@ -6821,9 +6223,7 @@
   "type": "Dividend",
   "company": "Vodafone",
   "symbol": "",
-  "date": {
-    "$date": "2011-08-05T00:00:00Z"
-  },
+  "date": "2011-08-05",
   "shares": 950,
   "amount": 47.48,
   "grossAmount": 0,
@@ -6843,9 +6243,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2011-08-16T00:00:00Z"
-  },
+  "date": "2011-08-16",
   "shares": 46,
   "amount": 12.43,
   "grossAmount": 0,
@@ -6865,9 +6263,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2011-09-09T00:00:00Z"
-  },
+  "date": "2011-09-09",
   "shares": 70,
   "amount": 19.6,
   "grossAmount": 0,
@@ -6887,9 +6283,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2011-09-06T00:00:00Z"
-  },
+  "date": "2011-09-06",
   "shares": 70,
   "amount": 15.51,
   "grossAmount": 0,
@@ -6909,9 +6303,7 @@
   "type": "Dividend",
   "company": "AstraZeneca",
   "symbol": "",
-  "date": {
-    "$date": "2011-09-12T00:00:00Z"
-  },
+  "date": "2011-09-12",
   "shares": 55,
   "amount": 23.87,
   "grossAmount": 0,
@@ -6931,9 +6323,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2011-09-06T00:00:00Z"
-  },
+  "date": "2011-09-06",
   "shares": 55,
   "amount": 10.43,
   "grossAmount": 0,
@@ -6953,9 +6343,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2011-09-13T00:00:00Z"
-  },
+  "date": "2011-09-13",
   "shares": 46,
   "amount": 14.14,
   "grossAmount": 0,
@@ -6975,9 +6363,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2011-09-01T00:00:00Z"
-  },
+  "date": "2011-09-01",
   "shares": 147,
   "amount": 15.92,
   "grossAmount": 0,
@@ -6997,9 +6383,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2011-09-14T00:00:00Z"
-  },
+  "date": "2011-09-14",
   "shares": 92,
   "amount": 15.28,
   "grossAmount": 0,
@@ -7019,9 +6403,7 @@
   "type": "Dividend",
   "company": "Total",
   "symbol": "",
-  "date": {
-    "$date": "2011-09-22T00:00:00Z"
-  },
+  "date": "2011-09-22",
   "shares": 51,
   "amount": 18.56,
   "grossAmount": 0,
@@ -7041,9 +6423,7 @@
   "type": "Dividend",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2011-09-29T00:00:00Z"
-  },
+  "date": "2011-09-29",
   "shares": 50,
   "amount": 22.7,
   "grossAmount": 0,
@@ -7063,9 +6443,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2011-09-30T00:00:00Z"
-  },
+  "date": "2011-09-30",
   "shares": 45,
   "amount": 12.75,
   "grossAmount": 0,
@@ -7085,9 +6463,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2011-10-11T00:00:00Z"
-  },
+  "date": "2011-10-11",
   "shares": 41,
   "amount": 16.71,
   "grossAmount": 0,
@@ -7107,9 +6483,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2011-11-16T00:00:00Z"
-  },
+  "date": "2011-11-16",
   "shares": 46,
   "amount": 13.13,
   "grossAmount": 0,
@@ -7129,9 +6503,7 @@
   "type": "Dividend",
   "company": "BAE Systems",
   "symbol": "",
-  "date": {
-    "$date": "2011-11-30T00:00:00Z"
-  },
+  "date": "2011-11-30",
   "shares": 570,
   "amount": 35.78,
   "grossAmount": 0,
@@ -7151,9 +6523,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2011-12-01T00:00:00Z"
-  },
+  "date": "2011-12-01",
   "shares": 147,
   "amount": 16.85,
   "grossAmount": 0,
@@ -7173,9 +6543,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2011-10-24T00:00:00Z"
-  },
+  "date": "2011-10-24",
   "shares": 150,
   "amount": 30.87,
   "grossAmount": 0,
@@ -7195,9 +6563,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2011-12-13T00:00:00Z"
-  },
+  "date": "2011-12-13",
   "shares": 46,
   "amount": 14.6,
   "grossAmount": 0,
@@ -7217,9 +6583,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2011-12-09T00:00:00Z"
-  },
+  "date": "2011-12-09",
   "shares": 70,
   "amount": 20.15,
   "grossAmount": 0,
@@ -7239,9 +6603,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2011-12-14T00:00:00Z"
-  },
+  "date": "2011-12-14",
   "shares": 92,
   "amount": 15.28,
   "grossAmount": 0,
@@ -7261,9 +6623,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2011-12-16T00:00:00Z"
-  },
+  "date": "2011-12-16",
   "shares": 88,
   "amount": 20.57,
   "grossAmount": 0,
@@ -7283,9 +6643,7 @@
   "type": "Dividend",
   "company": "Total",
   "symbol": "",
-  "date": {
-    "$date": "2011-12-22T00:00:00Z"
-  },
+  "date": "2011-12-22",
   "shares": 51,
   "amount": 18.56,
   "grossAmount": 0,
@@ -7305,9 +6663,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2012-01-03T00:00:00Z"
-  },
+  "date": "2012-01-03",
   "shares": 45,
   "amount": 13.12,
   "grossAmount": 0,
@@ -7327,9 +6683,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2012-01-11T00:00:00Z"
-  },
+  "date": "2012-01-11",
   "shares": 41,
   "amount": 17.78,
   "grossAmount": 0,
@@ -7349,9 +6703,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2012-01-03T00:00:00Z"
-  },
+  "date": "2012-01-03",
   "shares": 55,
   "amount": 11.37,
   "grossAmount": 0,
@@ -7371,9 +6723,7 @@
   "type": "Dividend",
   "company": "Vodafone",
   "symbol": "",
-  "date": {
-    "$date": "2012-02-03T00:00:00Z"
-  },
+  "date": "2012-02-03",
   "shares": 950,
   "amount": 58.07,
   "grossAmount": 0,
@@ -7393,9 +6743,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2012-02-15T00:00:00Z"
-  },
+  "date": "2012-02-15",
   "shares": 46,
   "amount": 13.53,
   "grossAmount": 0,
@@ -7415,9 +6763,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2012-03-01T00:00:00Z"
-  },
+  "date": "2012-03-01",
   "shares": 147,
   "amount": 17.03,
   "grossAmount": 0,
@@ -7437,9 +6783,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2012-02-17T00:00:00Z"
-  },
+  "date": "2012-02-17",
   "shares": 75,
   "amount": 43.52,
   "grossAmount": 0,
@@ -7459,9 +6803,7 @@
   "type": "Dividend",
   "company": "Novartis",
   "symbol": "NOVN.SW",
-  "date": {
-    "$date": "2012-03-01T00:00:00Z"
-  },
+  "date": "2012-03-01",
   "shares": 53,
   "amount": 53.05,
   "grossAmount": 0,
@@ -7481,9 +6823,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2012-03-09T00:00:00Z"
-  },
+  "date": "2012-03-09",
   "shares": 70,
   "amount": 20.48,
   "grossAmount": 0,
@@ -7503,9 +6843,7 @@
   "type": "Dividend",
   "company": "AstraZeneca",
   "symbol": "",
-  "date": {
-    "$date": "2012-03-19T00:00:00Z"
-  },
+  "date": "2012-03-19",
   "shares": 55,
   "amount": 58.88,
   "grossAmount": 0,
@@ -7525,9 +6863,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2012-03-13T00:00:00Z"
-  },
+  "date": "2012-03-13",
   "shares": 46,
   "amount": 14.74,
   "grossAmount": 0,
@@ -7547,9 +6883,7 @@
   "type": "Dividend",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2012-03-13T00:00:00Z"
-  },
+  "date": "2012-03-13",
   "shares": 18,
   "amount": 54.45,
   "grossAmount": 0,
@@ -7569,9 +6903,7 @@
   "type": "Dividend",
   "company": "Total",
   "symbol": "",
-  "date": {
-    "$date": "2012-03-22T00:00:00Z"
-  },
+  "date": "2012-03-22",
   "shares": 51,
   "amount": 17.11,
   "grossAmount": 0,
@@ -7591,9 +6923,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2012-03-22T00:00:00Z"
-  },
+  "date": "2012-03-22",
   "shares": 92,
   "amount": 15.28,
   "grossAmount": 0,
@@ -7613,9 +6943,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2012-03-22T00:00:00Z"
-  },
+  "date": "2012-03-22",
   "shares": 88,
   "amount": 20.81,
   "grossAmount": 0,
@@ -7635,9 +6963,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2012-04-04T00:00:00Z"
-  },
+  "date": "2012-04-04",
   "shares": 55,
   "amount": 12.21,
   "grossAmount": 0,
@@ -7657,9 +6983,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2012-04-10T00:00:00Z"
-  },
+  "date": "2012-04-10",
   "shares": 150,
   "amount": 21.65,
   "grossAmount": 0,
@@ -7679,9 +7003,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2012-03-30T00:00:00Z"
-  },
+  "date": "2012-03-30",
   "shares": 45,
   "amount": 12.8,
   "grossAmount": 0,
@@ -7701,9 +7023,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2012-04-11T00:00:00Z"
-  },
+  "date": "2012-04-11",
   "shares": 70,
   "amount": 5.72,
   "grossAmount": 0,
@@ -7723,9 +7043,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2012-04-12T00:00:00Z"
-  },
+  "date": "2012-04-12",
   "shares": 41,
   "amount": 17.29,
   "grossAmount": 0,
@@ -7745,9 +7063,7 @@
   "type": "Dividend",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2012-04-26T00:00:00Z"
-  },
+  "date": "2012-04-26",
   "shares": 48,
   "amount": 41.8,
   "grossAmount": 0,
@@ -7767,9 +7083,7 @@
   "type": "Dividend",
   "company": "Munich Re",
   "symbol": "MUV2.DE",
-  "date": {
-    "$date": "2012-04-27T00:00:00Z"
-  },
+  "date": "2012-04-27",
   "shares": 20,
   "amount": 90.01,
   "grossAmount": 0,
@@ -7789,9 +7103,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2012-05-15T00:00:00Z"
-  },
+  "date": "2012-05-15",
   "shares": 46,
   "amount": 14.82,
   "grossAmount": 0,
@@ -7811,9 +7123,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2012-05-02T00:00:00Z"
-  },
+  "date": "2012-05-02",
   "shares": 70,
   "amount": 27.4,
   "grossAmount": 0,
@@ -7833,9 +7143,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2012-06-01T00:00:00Z"
-  },
+  "date": "2012-06-01",
   "shares": 147,
   "amount": 18.44,
   "grossAmount": 0,
@@ -7855,9 +7163,7 @@
   "type": "Dividend",
   "company": "BAE Systems",
   "symbol": "",
-  "date": {
-    "$date": "2012-06-01T00:00:00Z"
-  },
+  "date": "2012-06-01",
   "shares": 570,
   "amount": 57.48,
   "grossAmount": 0,
@@ -7877,9 +7183,7 @@
   "type": "Dividend",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2012-05-31T00:00:00Z"
-  },
+  "date": "2012-05-31",
   "shares": 50,
   "amount": 31.41,
   "grossAmount": 0,
@@ -7899,9 +7203,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2012-06-04T00:00:00Z"
-  },
+  "date": "2012-06-04",
   "shares": 55,
   "amount": 12.95,
   "grossAmount": 0,
@@ -7921,9 +7223,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2012-06-08T00:00:00Z"
-  },
+  "date": "2012-06-08",
   "shares": 70,
   "amount": 15.7,
   "grossAmount": 0,
@@ -7943,9 +7243,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2012-06-12T00:00:00Z"
-  },
+  "date": "2012-06-12",
   "shares": 46,
   "amount": 16.49,
   "grossAmount": 0,
@@ -7965,9 +7263,7 @@
   "type": "Dividend",
   "company": "Total",
   "symbol": "",
-  "date": {
-    "$date": "2012-06-21T00:00:00Z"
-  },
+  "date": "2012-06-21",
   "shares": 51,
   "amount": 17.11,
   "grossAmount": 0,
@@ -7987,9 +7283,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2012-06-21T00:00:00Z"
-  },
+  "date": "2012-06-21",
   "shares": 88,
   "amount": 22.54,
   "grossAmount": 0,
@@ -8009,9 +7303,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2012-06-29T00:00:00Z"
-  },
+  "date": "2012-06-29",
   "shares": 45,
   "amount": 14.16,
   "grossAmount": 0,
@@ -8031,9 +7323,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2012-06-22T00:00:00Z"
-  },
+  "date": "2012-06-22",
   "shares": 92,
   "amount": 16.51,
   "grossAmount": 0,
@@ -8053,9 +7343,7 @@
   "type": "Dividend",
   "company": "Tesco",
   "symbol": "",
-  "date": {
-    "$date": "2012-07-06T00:00:00Z"
-  },
+  "date": "2012-07-06",
   "shares": 500,
   "amount": 45.81,
   "grossAmount": 0,
@@ -8075,9 +7363,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2012-07-12T00:00:00Z"
-  },
+  "date": "2012-07-12",
   "shares": 41,
   "amount": 18.64,
   "grossAmount": 0,
@@ -8097,9 +7383,7 @@
   "type": "Dividend",
   "company": "Vodafone",
   "symbol": "",
-  "date": {
-    "$date": "2012-08-01T00:00:00Z"
-  },
+  "date": "2012-08-01",
   "shares": 950,
   "amount": 56.06,
   "grossAmount": 0,
@@ -8119,9 +7403,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2012-08-15T00:00:00Z"
-  },
+  "date": "2012-08-15",
   "shares": 46,
   "amount": 15.49,
   "grossAmount": 0,
@@ -8141,9 +7423,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2012-08-17T00:00:00Z"
-  },
+  "date": "2012-08-17",
   "shares": 75,
   "amount": 21.69,
   "grossAmount": 0,
@@ -8163,9 +7443,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2012-09-01T00:00:00Z"
-  },
+  "date": "2012-09-01",
   "shares": 147,
   "amount": 19.34,
   "grossAmount": 0,
@@ -8185,9 +7463,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2012-09-04T00:00:00Z"
-  },
+  "date": "2012-09-04",
   "shares": 55,
   "amount": 12.78,
   "grossAmount": 0,
@@ -8207,9 +7483,7 @@
   "type": "Dividend",
   "company": "AstraZeneca",
   "symbol": "",
-  "date": {
-    "$date": "2012-09-10T00:00:00Z"
-  },
+  "date": "2012-09-10",
   "shares": 55,
   "amount": 28.71,
   "grossAmount": 0,
@@ -8229,9 +7503,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2012-09-11T00:00:00Z"
-  },
+  "date": "2012-09-11",
   "shares": 46,
   "amount": 16.11,
   "grossAmount": 0,
@@ -8251,9 +7523,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2012-09-04T00:00:00Z"
-  },
+  "date": "2012-09-04",
   "shares": 70,
   "amount": 17.06,
   "grossAmount": 0,
@@ -8273,9 +7543,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2012-09-10T00:00:00Z"
-  },
+  "date": "2012-09-10",
   "shares": 70,
   "amount": 21.13,
   "grossAmount": 0,
@@ -8295,9 +7563,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2012-09-12T00:00:00Z"
-  },
+  "date": "2012-09-12",
   "shares": 92,
   "amount": 16.51,
   "grossAmount": 0,
@@ -8317,9 +7583,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2012-09-20T00:00:00Z"
-  },
+  "date": "2012-09-20",
   "shares": 88,
   "amount": 22.22,
   "grossAmount": 0,
@@ -8339,9 +7603,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2012-09-21T00:00:00Z"
-  },
+  "date": "2012-09-21",
   "shares": 220,
   "amount": 8.3,
   "grossAmount": 0,
@@ -8361,9 +7623,7 @@
   "type": "Dividend",
   "company": "Total",
   "symbol": "",
-  "date": {
-    "$date": "2012-09-27T00:00:00Z"
-  },
+  "date": "2012-09-27",
   "shares": 51,
   "amount": 17.11,
   "grossAmount": 0,
@@ -8383,9 +7643,7 @@
   "type": "Dividend",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2012-09-27T00:00:00Z"
-  },
+  "date": "2012-09-27",
   "shares": 50,
   "amount": 25.32,
   "grossAmount": 0,
@@ -8405,9 +7663,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2012-09-28T00:00:00Z"
-  },
+  "date": "2012-09-28",
   "shares": 45,
   "amount": 13.78,
   "grossAmount": 0,
@@ -8427,9 +7683,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2012-10-22T00:00:00Z"
-  },
+  "date": "2012-10-22",
   "shares": 150,
   "amount": 36.01,
   "grossAmount": 0,
@@ -8449,9 +7703,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2012-11-15T00:00:00Z"
-  },
+  "date": "2012-11-15",
   "shares": 46,
   "amount": 14.92,
   "grossAmount": 0,
@@ -8471,9 +7723,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2012-12-03T00:00:00Z"
-  },
+  "date": "2012-12-03",
   "shares": 147,
   "amount": 18.68,
   "grossAmount": 0,
@@ -8493,9 +7743,7 @@
   "type": "Dividend",
   "company": "BAE Systems",
   "symbol": "",
-  "date": {
-    "$date": "2012-11-30T00:00:00Z"
-  },
+  "date": "2012-11-30",
   "shares": 570,
   "amount": 39.46,
   "grossAmount": 0,
@@ -8515,9 +7763,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2012-10-11T00:00:00Z"
-  },
+  "date": "2012-10-11",
   "shares": 41,
   "amount": 19.44,
   "grossAmount": 0,
@@ -8537,9 +7783,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2012-12-10T00:00:00Z"
-  },
+  "date": "2012-12-10",
   "shares": 148,
   "amount": 44.26,
   "grossAmount": 0,
@@ -8559,9 +7803,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2012-12-11T00:00:00Z"
-  },
+  "date": "2012-12-11",
   "shares": 46,
   "amount": 15.95,
   "grossAmount": 0,
@@ -8581,9 +7823,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2012-12-12T00:00:00Z"
-  },
+  "date": "2012-12-12",
   "shares": 92,
   "amount": 16.51,
   "grossAmount": 0,
@@ -8603,9 +7843,7 @@
   "type": "Dividend",
   "company": "Total",
   "symbol": "",
-  "date": {
-    "$date": "2012-12-20T00:00:00Z"
-  },
+  "date": "2012-12-20",
   "shares": 51,
   "amount": 17.69,
   "grossAmount": 0,
@@ -8625,9 +7863,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2013-01-02T00:00:00Z"
-  },
+  "date": "2013-01-02",
   "shares": 55,
   "amount": 12.15,
   "grossAmount": 0,
@@ -8647,9 +7883,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2012-12-20T00:00:00Z"
-  },
+  "date": "2012-12-20",
   "shares": 88,
   "amount": 21.66,
   "grossAmount": 0,
@@ -8669,9 +7903,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2013-01-02T00:00:00Z"
-  },
+  "date": "2013-01-02",
   "shares": 45,
   "amount": 13.43,
   "grossAmount": 0,
@@ -8691,9 +7923,7 @@
   "type": "Dividend",
   "company": "Tesco",
   "symbol": "",
-  "date": {
-    "$date": "2012-12-21T00:00:00Z"
-  },
+  "date": "2012-12-21",
   "shares": 1020,
   "amount": 41.71,
   "grossAmount": 0,
@@ -8713,9 +7943,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2013-01-11T00:00:00Z"
-  },
+  "date": "2013-01-11",
   "shares": 41,
   "amount": 18.94,
   "grossAmount": 0,
@@ -8735,9 +7963,7 @@
   "type": "Dividend",
   "company": "Siemens",
   "symbol": "SIE.DE",
-  "date": {
-    "$date": "2013-01-24T00:00:00Z"
-  },
+  "date": "2013-01-24",
   "shares": 31,
   "amount": 66.97,
   "grossAmount": 0,
@@ -8757,9 +7983,7 @@
   "type": "Dividend",
   "company": "Vodafone",
   "symbol": "",
-  "date": {
-    "$date": "2013-02-06T00:00:00Z"
-  },
+  "date": "2013-02-06",
   "shares": 950,
   "amount": 25.88,
   "grossAmount": 0,
@@ -8779,9 +8003,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2013-02-15T00:00:00Z"
-  },
+  "date": "2013-02-15",
   "shares": 46,
   "amount": 14.26,
   "grossAmount": 0,
@@ -8801,9 +8023,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2013-02-18T00:00:00Z"
-  },
+  "date": "2013-02-18",
   "shares": 75,
   "amount": 46.11,
   "grossAmount": 0,
@@ -8823,9 +8043,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2013-03-01T00:00:00Z"
-  },
+  "date": "2013-03-01",
   "shares": 147,
   "amount": 18.68,
   "grossAmount": 0,
@@ -8845,9 +8063,7 @@
   "type": "Dividend",
   "company": "Novartis",
   "symbol": "NOVN.SW",
-  "date": {
-    "$date": "2013-03-01T00:00:00Z"
-  },
+  "date": "2013-03-01",
   "shares": 53,
   "amount": 53.39,
   "grossAmount": 0,
@@ -8867,9 +8083,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2013-03-08T00:00:00Z"
-  },
+  "date": "2013-03-08",
   "shares": 148,
   "amount": 43.58,
   "grossAmount": 0,
@@ -8889,9 +8103,7 @@
   "type": "Dividend",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2013-03-12T00:00:00Z"
-  },
+  "date": "2013-03-12",
   "shares": 18,
   "amount": 57.56,
   "grossAmount": 0,
@@ -8911,9 +8123,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2013-03-13T00:00:00Z"
-  },
+  "date": "2013-03-13",
   "shares": 92,
   "amount": 16.51,
   "grossAmount": 0,
@@ -8933,9 +8143,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2013-03-12T00:00:00Z"
-  },
+  "date": "2013-03-12",
   "shares": 46,
   "amount": 15.9,
   "grossAmount": 0,
@@ -8955,9 +8163,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2013-03-14T00:00:00Z"
-  },
+  "date": "2013-03-14",
   "shares": 100,
   "amount": 13.09,
   "grossAmount": 0,
@@ -8977,9 +8183,7 @@
   "type": "Dividend",
   "company": "Total",
   "symbol": "",
-  "date": {
-    "$date": "2013-03-21T00:00:00Z"
-  },
+  "date": "2013-03-21",
   "shares": 51,
   "amount": 17.69,
   "grossAmount": 0,
@@ -8999,9 +8203,7 @@
   "type": "Dividend",
   "company": "AstraZeneca",
   "symbol": "",
-  "date": {
-    "$date": "2013-03-18T00:00:00Z"
-  },
+  "date": "2013-03-18",
   "shares": 55,
   "amount": 55.69,
   "grossAmount": 0,
@@ -9021,9 +8223,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2013-03-29T00:00:00Z"
-  },
+  "date": "2013-03-29",
   "shares": 45,
   "amount": 13.87,
   "grossAmount": 0,
@@ -9043,9 +8243,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2013-03-28T00:00:00Z"
-  },
+  "date": "2013-03-28",
   "shares": 88,
   "amount": 21.53,
   "grossAmount": 0,
@@ -9065,9 +8263,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2013-04-01T00:00:00Z"
-  },
+  "date": "2013-04-01",
   "shares": 55,
   "amount": 14.82,
   "grossAmount": 0,
@@ -9087,9 +8283,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2013-04-08T00:00:00Z"
-  },
+  "date": "2013-04-08",
   "shares": 150,
   "amount": 22.94,
   "grossAmount": 0,
@@ -9109,9 +8303,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2013-04-12T00:00:00Z"
-  },
+  "date": "2013-04-12",
   "shares": 41,
   "amount": 19.21,
   "grossAmount": 0,
@@ -9131,9 +8323,7 @@
   "type": "Dividend",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2013-04-18T00:00:00Z"
-  },
+  "date": "2013-04-18",
   "shares": 48,
   "amount": 43.41,
   "grossAmount": 0,
@@ -9153,9 +8343,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2013-04-23T00:00:00Z"
-  },
+  "date": "2013-04-23",
   "shares": 143,
   "amount": 85.82,
   "grossAmount": 0,
@@ -9175,9 +8363,7 @@
   "type": "Dividend",
   "company": "Munich Re",
   "symbol": "MUV2.DE",
-  "date": {
-    "$date": "2013-04-26T00:00:00Z"
-  },
+  "date": "2013-04-26",
   "shares": 20,
   "amount": 100.81,
   "grossAmount": 0,
@@ -9197,9 +8383,7 @@
   "type": "Dividend",
   "company": "GBL",
   "symbol": "GBLB.BR",
-  "date": {
-    "$date": "2013-05-03T00:00:00Z"
-  },
+  "date": "2013-05-03",
   "shares": 37,
   "amount": 62.57,
   "grossAmount": 0,
@@ -9219,9 +8403,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2013-05-08T00:00:00Z"
-  },
+  "date": "2013-05-08",
   "shares": 70,
   "amount": 28.94,
   "grossAmount": 0,
@@ -9241,9 +8423,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2013-05-15T00:00:00Z"
-  },
+  "date": "2013-05-15",
   "shares": 46,
   "amount": 15.81,
   "grossAmount": 0,
@@ -9263,9 +8443,7 @@
   "type": "Dividend",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2013-05-30T00:00:00Z"
-  },
+  "date": "2013-05-30",
   "shares": 50,
   "amount": 32.68,
   "grossAmount": 0,
@@ -9285,9 +8463,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2013-06-03T00:00:00Z"
-  },
+  "date": "2013-06-03",
   "shares": 147,
   "amount": 18.71,
   "grossAmount": 0,
@@ -9307,9 +8483,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2013-06-03T00:00:00Z"
-  },
+  "date": "2013-06-03",
   "shares": 55,
   "amount": 14.62,
   "grossAmount": 0,
@@ -9329,9 +8503,7 @@
   "type": "Dividend",
   "company": "BAE Systems",
   "symbol": "",
-  "date": {
-    "$date": "2013-06-03T00:00:00Z"
-  },
+  "date": "2013-06-03",
   "shares": 570,
   "amount": 56.11,
   "grossAmount": 0,
@@ -9351,9 +8523,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2013-06-07T00:00:00Z"
-  },
+  "date": "2013-06-07",
   "shares": 220,
   "amount": 40.5,
   "grossAmount": 0,
@@ -9373,9 +8543,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2013-06-10T00:00:00Z"
-  },
+  "date": "2013-06-10",
   "shares": 148,
   "amount": 25.52,
   "grossAmount": 0,
@@ -9395,9 +8563,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2013-06-11T00:00:00Z"
-  },
+  "date": "2013-06-11",
   "shares": 46,
   "amount": 16.81,
   "grossAmount": 0,
@@ -9417,9 +8583,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2013-06-12T00:00:00Z"
-  },
+  "date": "2013-06-12",
   "shares": 92,
   "amount": 18.28,
   "grossAmount": 0,
@@ -9439,9 +8603,7 @@
   "type": "Dividend",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2013-06-14T00:00:00Z"
-  },
+  "date": "2013-06-14",
   "shares": 61,
   "amount": 2.12,
   "grossAmount": 0,
@@ -9461,9 +8623,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2013-06-13T00:00:00Z"
-  },
+  "date": "2013-06-13",
   "shares": 100,
   "amount": 12.69,
   "grossAmount": 0,
@@ -9483,9 +8643,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2013-06-27T00:00:00Z"
-  },
+  "date": "2013-06-27",
   "shares": 88,
   "amount": 22.16,
   "grossAmount": 0,
@@ -9505,9 +8663,7 @@
   "type": "Dividend",
   "company": "Tesco",
   "symbol": "",
-  "date": {
-    "$date": "2013-07-05T00:00:00Z"
-  },
+  "date": "2013-07-05",
   "shares": 1020,
   "amount": 86.23,
   "grossAmount": 0,
@@ -9527,9 +8683,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2013-06-28T00:00:00Z"
-  },
+  "date": "2013-06-28",
   "shares": 45,
   "amount": 14.39,
   "grossAmount": 0,
@@ -9549,9 +8703,7 @@
   "type": "Dividend",
   "company": "Siemens",
   "symbol": "SIE.DE",
-  "date": {
-    "$date": "2013-07-11T00:00:00Z"
-  },
+  "date": "2013-07-11",
   "shares": 31,
   "amount": 75.38,
   "grossAmount": 0,
@@ -9571,9 +8723,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2013-07-12T00:00:00Z"
-  },
+  "date": "2013-07-12",
   "shares": 41,
   "amount": 19.21,
   "grossAmount": 0,
@@ -9593,9 +8743,7 @@
   "type": "Dividend",
   "company": "Vodafone",
   "symbol": "",
-  "date": {
-    "$date": "2013-08-07T00:00:00Z"
-  },
+  "date": "2013-08-07",
   "shares": 950,
   "amount": 54.8,
   "grossAmount": 0,
@@ -9615,9 +8763,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2013-08-15T00:00:00Z"
-  },
+  "date": "2013-08-15",
   "shares": 46,
   "amount": 15.32,
   "grossAmount": 0,
@@ -9637,9 +8783,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2013-08-16T00:00:00Z"
-  },
+  "date": "2013-08-16",
   "shares": 75,
   "amount": 22.22,
   "grossAmount": 0,
@@ -9659,9 +8803,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2013-09-01T00:00:00Z"
-  },
+  "date": "2013-09-01",
   "shares": 147,
   "amount": 18.5,
   "grossAmount": 0,
@@ -9681,9 +8823,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2013-09-03T00:00:00Z"
-  },
+  "date": "2013-09-03",
   "shares": 55,
   "amount": 14.47,
   "grossAmount": 0,
@@ -9703,9 +8843,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2013-09-03T00:00:00Z"
-  },
+  "date": "2013-09-03",
   "shares": 70,
   "amount": 18.61,
   "grossAmount": 0,
@@ -9725,9 +8863,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2013-09-10T00:00:00Z"
-  },
+  "date": "2013-09-10",
   "shares": 46,
   "amount": 16.9,
   "grossAmount": 0,
@@ -9747,9 +8883,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2013-09-10T00:00:00Z"
-  },
+  "date": "2013-09-10",
   "shares": 148,
   "amount": 25.54,
   "grossAmount": 0,
@@ -9769,9 +8903,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2013-09-11T00:00:00Z"
-  },
+  "date": "2013-09-11",
   "shares": 92,
   "amount": 18.28,
   "grossAmount": 0,
@@ -9791,9 +8923,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2013-09-12T00:00:00Z"
-  },
+  "date": "2013-09-12",
   "shares": 100,
   "amount": 12.74,
   "grossAmount": 0,
@@ -9813,9 +8943,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2013-09-13T00:00:00Z"
-  },
+  "date": "2013-09-13",
   "shares": 220,
   "amount": 8.9,
   "grossAmount": 0,
@@ -9835,9 +8963,7 @@
   "type": "Dividend",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2013-09-16T00:00:00Z"
-  },
+  "date": "2013-09-16",
   "shares": 61,
   "amount": 2.11,
   "grossAmount": 0,
@@ -9857,9 +8983,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2013-09-26T00:00:00Z"
-  },
+  "date": "2013-09-26",
   "shares": 88,
   "amount": 22.12,
   "grossAmount": 0,
@@ -9879,9 +9003,7 @@
   "type": "Dividend",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2013-09-26T00:00:00Z"
-  },
+  "date": "2013-09-26",
   "shares": 50,
   "amount": 25.6,
   "grossAmount": 0,
@@ -9901,9 +9023,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2013-09-30T00:00:00Z"
-  },
+  "date": "2013-09-30",
   "shares": 49,
   "amount": 5.9,
   "grossAmount": 0,
@@ -9923,9 +9043,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2013-09-30T00:00:00Z"
-  },
+  "date": "2013-09-30",
   "shares": 45,
   "amount": 13.93,
   "grossAmount": 0,
@@ -9945,9 +9063,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2013-10-03T00:00:00Z"
-  },
+  "date": "2013-10-03",
   "shares": 150,
   "amount": 37.62,
   "grossAmount": 0,
@@ -9967,9 +9083,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2013-10-11T00:00:00Z"
-  },
+  "date": "2013-10-11",
   "shares": 41,
   "amount": 20.44,
   "grossAmount": 0,
@@ -9989,9 +9103,7 @@
   "type": "Dividend",
   "company": "\"Jardine Matheson \"",
   "symbol": "J36.SI",
-  "date": {
-    "$date": "2013-10-16T00:00:00Z"
-  },
+  "date": "2013-10-16",
   "shares": 50,
   "amount": 9.82,
   "grossAmount": 0,
@@ -10011,9 +9123,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2013-11-15T00:00:00Z"
-  },
+  "date": "2013-11-15",
   "shares": 46,
   "amount": 15.15,
   "grossAmount": 0,
@@ -10033,9 +9143,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2013-12-01T00:00:00Z"
-  },
+  "date": "2013-12-01",
   "shares": 147,
   "amount": 17.93,
   "grossAmount": 0,
@@ -10055,9 +9163,7 @@
   "type": "Dividend",
   "company": "BAE Systems",
   "symbol": "",
-  "date": {
-    "$date": "2013-12-02T00:00:00Z"
-  },
+  "date": "2013-12-02",
   "shares": 570,
   "amount": 39.71,
   "grossAmount": 0,
@@ -10077,9 +9183,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2013-12-10T00:00:00Z"
-  },
+  "date": "2013-12-10",
   "shares": 148,
   "amount": 24.57,
   "grossAmount": 0,
@@ -10099,9 +9203,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2013-12-10T00:00:00Z"
-  },
+  "date": "2013-12-10",
   "shares": 46,
   "amount": 16.26,
   "grossAmount": 0,
@@ -10121,9 +9223,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2013-12-11T00:00:00Z"
-  },
+  "date": "2013-12-11",
   "shares": 92,
   "amount": 18.28,
   "grossAmount": 0,
@@ -10143,9 +9243,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2013-12-13T00:00:00Z"
-  },
+  "date": "2013-12-13",
   "shares": 100,
   "amount": 14.97,
   "grossAmount": 0,
@@ -10165,9 +9263,7 @@
   "type": "Dividend",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2013-12-13T00:00:00Z"
-  },
+  "date": "2013-12-13",
   "shares": 61,
   "amount": 2.05,
   "grossAmount": 0,
@@ -10187,9 +9283,7 @@
   "type": "Dividend",
   "company": "Tesco",
   "symbol": "",
-  "date": {
-    "$date": "2013-12-20T00:00:00Z"
-  },
+  "date": "2013-12-20",
   "shares": 1020,
   "amount": 40.55,
   "grossAmount": 0,
@@ -10209,9 +9303,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2013-12-23T00:00:00Z"
-  },
+  "date": "2013-12-23",
   "shares": 171,
   "amount": 41.53,
   "grossAmount": 0,
@@ -10231,9 +9323,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2013-12-31T00:00:00Z"
-  },
+  "date": "2013-12-31",
   "shares": 49,
   "amount": 5.79,
   "grossAmount": 0,
@@ -10253,9 +9343,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2014-01-02T00:00:00Z"
-  },
+  "date": "2014-01-02",
   "shares": 45,
   "amount": 13.69,
   "grossAmount": 0,
@@ -10275,9 +9363,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2014-01-02T00:00:00Z"
-  },
+  "date": "2014-01-02",
   "shares": 55,
   "amount": 13.87,
   "grossAmount": 0,
@@ -10297,9 +9383,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2014-01-10T00:00:00Z"
-  },
+  "date": "2014-01-10",
   "shares": 41,
   "amount": 20.41,
   "grossAmount": 0,
@@ -10319,9 +9403,7 @@
   "type": "Dividend",
   "company": "Siemens",
   "symbol": "SIE.DE",
-  "date": {
-    "$date": "2014-01-29T00:00:00Z"
-  },
+  "date": "2014-01-29",
   "shares": 31,
   "amount": 66.97,
   "grossAmount": 0,
@@ -10341,9 +9423,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2014-02-03T00:00:00Z"
-  },
+  "date": "2014-02-03",
   "shares": 25,
   "amount": 6.95,
   "grossAmount": 0,
@@ -10363,9 +9443,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2014-02-17T00:00:00Z"
-  },
+  "date": "2014-02-17",
   "shares": 153,
   "amount": 108.92,
   "grossAmount": 0,
@@ -10385,9 +9463,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2014-02-27T00:00:00Z"
-  },
+  "date": "2014-02-27",
   "shares": 48,
   "amount": 1.44,
   "grossAmount": 0,
@@ -10407,9 +9483,7 @@
   "type": "Dividend",
   "company": "Novartis",
   "symbol": "NOVN.SW",
-  "date": {
-    "$date": "2014-02-27T00:00:00Z"
-  },
+  "date": "2014-02-27",
   "shares": 53,
   "amount": 57.27,
   "grossAmount": 0,
@@ -10429,9 +9503,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2014-03-01T00:00:00Z"
-  },
+  "date": "2014-03-01",
   "shares": 147,
   "amount": 17.68,
   "grossAmount": 0,
@@ -10451,9 +9523,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2014-02-18T00:00:00Z"
-  },
+  "date": "2014-02-18",
   "shares": 46,
   "amount": 14.88,
   "grossAmount": 0,
@@ -10473,9 +9543,7 @@
   "type": "Dividend",
   "company": "\"Gold Fields Limited \"",
   "symbol": "GFI",
-  "date": {
-    "$date": "2014-03-10T00:00:00Z"
-  },
+  "date": "2014-03-10",
   "shares": 162,
   "amount": 1.77,
   "grossAmount": 0,
@@ -10495,9 +9563,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2014-03-10T00:00:00Z"
-  },
+  "date": "2014-03-10",
   "shares": 148,
   "amount": 24.37,
   "grossAmount": 0,
@@ -10517,9 +9583,7 @@
   "type": "Dividend",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2014-03-11T00:00:00Z"
-  },
+  "date": "2014-03-11",
   "shares": 18,
   "amount": 61.84,
   "grossAmount": 0,
@@ -10539,9 +9603,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2014-03-11T00:00:00Z"
-  },
+  "date": "2014-03-11",
   "shares": 46,
   "amount": 16.14,
   "grossAmount": 0,
@@ -10561,9 +9623,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2014-03-12T00:00:00Z"
-  },
+  "date": "2014-03-12",
   "shares": 92,
   "amount": 18.28,
   "grossAmount": 0,
@@ -10583,9 +9643,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2014-03-13T00:00:00Z"
-  },
+  "date": "2014-03-13",
   "shares": 100,
   "amount": 14.77,
   "grossAmount": 0,
@@ -10605,9 +9663,7 @@
   "type": "Dividend",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2014-03-14T00:00:00Z"
-  },
+  "date": "2014-03-14",
   "shares": 61,
   "amount": 2.03,
   "grossAmount": 0,
@@ -10627,9 +9683,7 @@
   "type": "Dividend",
   "company": "\"Weyerhaeuser \"",
   "symbol": "WY",
-  "date": {
-    "$date": "2014-03-14T00:00:00Z"
-  },
+  "date": "2014-03-14",
   "shares": 75,
   "amount": 8.74,
   "grossAmount": 0,
@@ -10649,9 +9703,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2014-03-17T00:00:00Z"
-  },
+  "date": "2014-03-17",
   "shares": 123,
   "amount": 3.27,
   "grossAmount": 0,
@@ -10671,9 +9723,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2014-03-27T00:00:00Z"
-  },
+  "date": "2014-03-27",
   "shares": 48,
   "amount": 1.47,
   "grossAmount": 0,
@@ -10693,9 +9743,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2014-03-19T00:00:00Z"
-  },
+  "date": "2014-03-19",
   "shares": 6570,
   "amount": 403.98,
   "grossAmount": 0,
@@ -10715,9 +9763,7 @@
   "type": "Dividend",
   "company": "\"White Mountains \"",
   "symbol": "WTM",
-  "date": {
-    "$date": "2014-03-27T00:00:00Z"
-  },
+  "date": "2014-03-27",
   "shares": 3,
   "amount": 1.58,
   "grossAmount": 0,
@@ -10737,9 +9783,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2014-03-27T00:00:00Z"
-  },
+  "date": "2014-03-27",
   "shares": 114,
   "amount": 9.15,
   "grossAmount": 0,
@@ -10759,9 +9803,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2014-03-27T00:00:00Z"
-  },
+  "date": "2014-03-27",
   "shares": 171,
   "amount": 40.95,
   "grossAmount": 0,
@@ -10781,9 +9823,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2014-03-31T00:00:00Z"
-  },
+  "date": "2014-03-31",
   "shares": 44,
   "amount": 11.54,
   "grossAmount": 0,
@@ -10803,9 +9843,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2014-03-28T00:00:00Z"
-  },
+  "date": "2014-03-28",
   "shares": 300,
   "amount": 69.04,
   "grossAmount": 0,
@@ -10825,9 +9863,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2014-03-31T00:00:00Z"
-  },
+  "date": "2014-03-31",
   "shares": 49,
   "amount": 5.76,
   "grossAmount": 0,
@@ -10847,9 +9883,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2014-04-01T00:00:00Z"
-  },
+  "date": "2014-04-01",
   "shares": 55,
   "amount": 14.09,
   "grossAmount": 0,
@@ -10869,9 +9903,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2014-03-31T00:00:00Z"
-  },
+  "date": "2014-03-31",
   "shares": 45,
   "amount": 13.66,
   "grossAmount": 0,
@@ -10891,9 +9923,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2014-04-11T00:00:00Z"
-  },
+  "date": "2014-04-11",
   "shares": 41,
   "amount": 19.95,
   "grossAmount": 0,
@@ -10913,9 +9943,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2014-04-07T00:00:00Z"
-  },
+  "date": "2014-04-07",
   "shares": 150,
   "amount": 25.7,
   "grossAmount": 0,
@@ -10935,9 +9963,7 @@
   "type": "Dividend",
   "company": "\"Yamana Gold \"",
   "symbol": "AUY",
-  "date": {
-    "$date": "2014-04-14T00:00:00Z"
-  },
+  "date": "2014-04-14",
   "shares": 215,
   "amount": 4.33,
   "grossAmount": 0,
@@ -10957,9 +9983,7 @@
   "type": "Dividend",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2014-04-17T00:00:00Z"
-  },
+  "date": "2014-04-17",
   "shares": 48,
   "amount": 45.49,
   "grossAmount": 0,
@@ -10979,9 +10003,7 @@
   "type": "Dividend",
   "company": "Orkla",
   "symbol": "OKL.F",
-  "date": {
-    "$date": "2014-04-25T00:00:00Z"
-  },
+  "date": "2014-04-25",
   "shares": 360,
   "amount": 50.87,
   "grossAmount": 0,
@@ -11001,9 +10023,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2014-05-01T00:00:00Z"
-  },
+  "date": "2014-05-01",
   "shares": 101,
   "amount": 18.67,
   "grossAmount": 0,
@@ -11023,9 +10043,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2014-05-01T00:00:00Z"
-  },
+  "date": "2014-05-01",
   "shares": 25,
   "amount": 6.78,
   "grossAmount": 0,
@@ -11045,9 +10063,7 @@
   "type": "Dividend",
   "company": "Munich Re",
   "symbol": "MUV2.DE",
-  "date": {
-    "$date": "2014-05-02T00:00:00Z"
-  },
+  "date": "2014-05-02",
   "shares": 20,
   "amount": 104.42,
   "grossAmount": 0,
@@ -11067,9 +10083,7 @@
   "type": "Dividend",
   "company": "GBL",
   "symbol": "GBLB.BR",
-  "date": {
-    "$date": "2014-05-05T00:00:00Z"
-  },
+  "date": "2014-05-05",
   "shares": 37,
   "amount": 64.22,
   "grossAmount": 0,
@@ -11089,9 +10103,7 @@
   "type": "Dividend",
   "company": "HSBC",
   "symbol": "",
-  "date": {
-    "$date": "2014-04-30T00:00:00Z"
-  },
+  "date": "2014-04-30",
   "shares": 265,
   "amount": 36.35,
   "grossAmount": 0,
@@ -11111,9 +10123,7 @@
   "type": "Dividend",
   "company": "British American Tobacco",
   "symbol": "BATS.L",
-  "date": {
-    "$date": "2014-05-08T00:00:00Z"
-  },
+  "date": "2014-05-08",
   "shares": 40,
   "amount": 47.3,
   "grossAmount": 0,
@@ -11133,9 +10143,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2014-05-08T00:00:00Z"
-  },
+  "date": "2014-05-08",
   "shares": 70,
   "amount": 27.4,
   "grossAmount": 0,
@@ -11155,9 +10163,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2014-05-14T00:00:00Z"
-  },
+  "date": "2014-05-14",
   "shares": 220,
   "amount": 103.98,
   "grossAmount": 0,
@@ -11177,9 +10183,7 @@
   "type": "Dividend",
   "company": "\"Jardine Matheson \"",
   "symbol": "J36.SI",
-  "date": {
-    "$date": "2014-05-14T00:00:00Z"
-  },
+  "date": "2014-05-14",
   "shares": 50,
   "amount": 27.06,
   "grossAmount": 0,
@@ -11199,9 +10203,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2014-05-14T00:00:00Z"
-  },
+  "date": "2014-05-14",
   "shares": 143,
   "amount": 93.59,
   "grossAmount": 0,
@@ -11221,9 +10223,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2014-05-15T00:00:00Z"
-  },
+  "date": "2014-05-15",
   "shares": 46,
   "amount": 15.95,
   "grossAmount": 0,
@@ -11243,9 +10243,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2014-06-02T00:00:00Z"
-  },
+  "date": "2014-06-02",
   "shares": 55,
   "amount": 14.29,
   "grossAmount": 0,
@@ -11265,9 +10263,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2014-06-01T00:00:00Z"
-  },
+  "date": "2014-06-01",
   "shares": 147,
   "amount": 17.9,
   "grossAmount": 0,
@@ -11287,9 +10283,7 @@
   "type": "Dividend",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2014-05-29T00:00:00Z"
-  },
+  "date": "2014-05-29",
   "shares": 50,
   "amount": 33.95,
   "grossAmount": 0,
@@ -11309,9 +10303,7 @@
   "type": "Dividend",
   "company": "\"Weyerhaeuser \"",
   "symbol": "WY",
-  "date": {
-    "$date": "2014-05-30T00:00:00Z"
-  },
+  "date": "2014-05-30",
   "shares": 75,
   "amount": 8.93,
   "grossAmount": 0,
@@ -11331,9 +10323,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2014-06-05T00:00:00Z"
-  },
+  "date": "2014-06-05",
   "shares": 220,
   "amount": 43.41,
   "grossAmount": 0,
@@ -11353,9 +10343,7 @@
   "type": "Dividend",
   "company": "BAE Systems",
   "symbol": "",
-  "date": {
-    "$date": "2014-06-02T00:00:00Z"
-  },
+  "date": "2014-06-02",
   "shares": 0,
   "amount": 60.98,
   "grossAmount": 0,
@@ -11374,9 +10362,7 @@
   "type": "Dividend",
   "company": "Excelon",
   "symbol": "",
-  "date": {
-    "$date": "2014-06-10T00:00:00Z"
-  },
+  "date": "2014-06-10",
   "shares": 0,
   "amount": 24.92,
   "grossAmount": 0,
@@ -11395,9 +10381,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2014-06-10T00:00:00Z"
-  },
+  "date": "2014-06-10",
   "shares": 46,
   "amount": 17.49,
   "grossAmount": 0,
@@ -11417,9 +10401,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2014-06-11T00:00:00Z"
-  },
+  "date": "2014-06-11",
   "shares": 92,
   "amount": 19.35,
   "grossAmount": 0,
@@ -11439,9 +10421,7 @@
   "type": "Dividend",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2014-06-13T00:00:00Z"
-  },
+  "date": "2014-06-13",
   "shares": 61,
   "amount": 2.08,
   "grossAmount": 0,
@@ -11461,9 +10441,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2014-06-12T00:00:00Z"
-  },
+  "date": "2014-06-12",
   "shares": 100,
   "amount": 15.24,
   "grossAmount": 0,
@@ -11483,9 +10461,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2014-06-11T00:00:00Z"
-  },
+  "date": "2014-06-11",
   "shares": 6570,
   "amount": 885.11,
   "grossAmount": 0,
@@ -11505,9 +10481,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2014-06-16T00:00:00Z"
-  },
+  "date": "2014-06-16",
   "shares": 123,
   "amount": 3.33,
   "grossAmount": 0,
@@ -11527,9 +10501,7 @@
   "type": "Dividend",
   "company": "First Pacific",
   "symbol": "0142.HK",
-  "date": {
-    "$date": "2014-06-23T00:00:00Z"
-  },
+  "date": "2014-06-23",
   "shares": 4000,
   "amount": 35.3,
   "grossAmount": 0,
@@ -11549,9 +10521,7 @@
   "type": "Dividend",
   "company": "Great Eagle Holdings",
   "symbol": "0041.HK",
-  "date": {
-    "$date": "2014-06-18T00:00:00Z"
-  },
+  "date": "2014-06-18",
   "shares": 1000,
   "amount": 63.45,
   "grossAmount": 0,
@@ -11571,9 +10541,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2014-06-26T00:00:00Z"
-  },
+  "date": "2014-06-26",
   "shares": 48,
   "amount": 5.3,
   "grossAmount": 0,
@@ -11593,9 +10561,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2014-06-26T00:00:00Z"
-  },
+  "date": "2014-06-26",
   "shares": 114,
   "amount": 1.54,
   "grossAmount": 0,
@@ -11615,9 +10581,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2014-06-27T00:00:00Z"
-  },
+  "date": "2014-06-27",
   "shares": 300,
   "amount": 86.03,
   "grossAmount": 0,
@@ -11637,9 +10601,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2014-06-26T00:00:00Z"
-  },
+  "date": "2014-06-26",
   "shares": 171,
   "amount": 43.78,
   "grossAmount": 0,
@@ -11659,9 +10621,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2014-06-30T00:00:00Z"
-  },
+  "date": "2014-06-30",
   "shares": 45,
   "amount": 15.91,
   "grossAmount": 0,
@@ -11681,9 +10641,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2014-06-30T00:00:00Z"
-  },
+  "date": "2014-06-30",
   "shares": 49,
   "amount": 6.35,
   "grossAmount": 0,
@@ -11703,9 +10661,7 @@
   "type": "Dividend",
   "company": "Tesco",
   "symbol": "",
-  "date": {
-    "$date": "2014-07-04T00:00:00Z"
-  },
+  "date": "2014-07-04",
   "shares": 1020,
   "amount": 93.61,
   "grossAmount": 0,
@@ -11725,9 +10681,7 @@
   "type": "Dividend",
   "company": "HSBC",
   "symbol": "",
-  "date": {
-    "$date": "2014-07-10T00:00:00Z"
-  },
+  "date": "2014-07-10",
   "shares": 265,
   "amount": 14.01,
   "grossAmount": 0,
@@ -11747,9 +10701,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2014-07-11T00:00:00Z"
-  },
+  "date": "2014-07-11",
   "shares": 41,
   "amount": 20.37,
   "grossAmount": 0,
@@ -11769,9 +10721,7 @@
   "type": "Dividend",
   "company": "\"Yamana Gold \"",
   "symbol": "AUY",
-  "date": {
-    "$date": "2014-07-14T00:00:00Z"
-  },
+  "date": "2014-07-14",
   "shares": 480,
   "amount": 9.69,
   "grossAmount": 0,
@@ -11791,9 +10741,7 @@
   "type": "Dividend",
   "company": "\"ISHSIII-C.EO CORP.B.EODIS \"",
   "symbol": "IEAC.AS",
-  "date": {
-    "$date": "2014-07-16T00:00:00Z"
-  },
+  "date": "2014-07-16",
   "shares": 490,
   "amount": 548.34,
   "grossAmount": 0,
@@ -11813,9 +10761,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2014-08-15T00:00:00Z"
-  },
+  "date": "2014-08-15",
   "shares": 46,
   "amount": 16.3,
   "grossAmount": 0,
@@ -11835,9 +10781,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2014-08-19T00:00:00Z"
-  },
+  "date": "2014-08-19",
   "shares": 153,
   "amount": 53.15,
   "grossAmount": 0,
@@ -11857,9 +10801,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2014-08-01T00:00:00Z"
-  },
+  "date": "2014-08-01",
   "shares": 25,
   "amount": 8.24,
   "grossAmount": 0,
@@ -11879,9 +10821,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2014-07-18T00:00:00Z"
-  },
+  "date": "2014-07-18",
   "shares": 33,
   "amount": 3.78,
   "grossAmount": 0,
@@ -11901,9 +10841,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2014-08-01T00:00:00Z"
-  },
+  "date": "2014-08-01",
   "shares": 101,
   "amount": 19.43,
   "grossAmount": 0,
@@ -11923,9 +10861,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2014-09-03T00:00:00Z"
-  },
+  "date": "2014-09-03",
   "shares": 55,
   "amount": 14.78,
   "grossAmount": 0,
@@ -11945,9 +10881,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2014-09-02T00:00:00Z"
-  },
+  "date": "2014-09-02",
   "shares": 70,
   "amount": 18.61,
   "grossAmount": 0,
@@ -11967,9 +10901,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2014-09-01T00:00:00Z"
-  },
+  "date": "2014-09-01",
   "shares": 147,
   "amount": 18.58,
   "grossAmount": 0,
@@ -11989,9 +10921,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2014-08-15T00:00:00Z"
-  },
+  "date": "2014-08-15",
   "shares": 77,
   "amount": 21.18,
   "grossAmount": 0,
@@ -12011,9 +10941,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2014-09-10T00:00:00Z"
-  },
+  "date": "2014-09-10",
   "shares": 92,
   "amount": 19.35,
   "grossAmount": 0,
@@ -12033,9 +10961,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2014-09-10T00:00:00Z"
-  },
+  "date": "2014-09-10",
   "shares": 46,
   "amount": 18.43,
   "grossAmount": 0,
@@ -12055,9 +10981,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2014-09-10T00:00:00Z"
-  },
+  "date": "2014-09-10",
   "shares": 6570,
   "amount": 740.82,
   "grossAmount": 0,
@@ -12077,9 +11001,7 @@
   "type": "Dividend",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2014-09-12T00:00:00Z"
-  },
+  "date": "2014-09-12",
   "shares": 61,
   "amount": 2.18,
   "grossAmount": 0,
@@ -12099,9 +11021,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2014-09-12T00:00:00Z"
-  },
+  "date": "2014-09-12",
   "shares": 100,
   "amount": 15.96,
   "grossAmount": 0,
@@ -12121,9 +11041,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2014-09-12T00:00:00Z"
-  },
+  "date": "2014-09-12",
   "shares": 220,
   "amount": 10.07,
   "grossAmount": 0,
@@ -12143,9 +11061,7 @@
   "type": "Dividend",
   "company": "\"Gold Fields Limited \"",
   "symbol": "GFI",
-  "date": {
-    "$date": "2014-09-15T00:00:00Z"
-  },
+  "date": "2014-09-15",
   "shares": 162,
   "amount": 1.68,
   "grossAmount": 0,
@@ -12165,9 +11081,7 @@
   "type": "Dividend",
   "company": "\"Weyerhaeuser \"",
   "symbol": "WY",
-  "date": {
-    "$date": "2014-09-12T00:00:00Z"
-  },
+  "date": "2014-09-12",
   "shares": 75,
   "amount": 12.41,
   "grossAmount": 0,
@@ -12187,9 +11101,7 @@
   "type": "Dividend",
   "company": "\"Tai Cheung \"",
   "symbol": "0088.HK",
-  "date": {
-    "$date": "2014-09-16T00:00:00Z"
-  },
+  "date": "2014-09-16",
   "shares": 4000,
   "amount": 54.3,
   "grossAmount": 0,
@@ -12209,9 +11121,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2014-09-15T00:00:00Z"
-  },
+  "date": "2014-09-15",
   "shares": 123,
   "amount": 3.5,
   "grossAmount": 0,
@@ -12231,9 +11141,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2014-09-25T00:00:00Z"
-  },
+  "date": "2014-09-25",
   "shares": 171,
   "amount": 45.85,
   "grossAmount": 0,
@@ -12253,9 +11161,7 @@
   "type": "Dividend",
   "company": "First Pacific",
   "symbol": "0142.HK",
-  "date": {
-    "$date": "2014-09-24T00:00:00Z"
-  },
+  "date": "2014-09-24",
   "shares": 4000,
   "amount": 23.04,
   "grossAmount": 0,
@@ -12275,9 +11181,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2014-09-26T00:00:00Z"
-  },
+  "date": "2014-09-26",
   "shares": 114,
   "amount": 1.66,
   "grossAmount": 0,
@@ -12297,9 +11201,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2014-09-25T00:00:00Z"
-  },
+  "date": "2014-09-25",
   "shares": 48,
   "amount": 5.47,
   "grossAmount": 0,
@@ -12319,9 +11221,7 @@
   "type": "Dividend",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2014-09-25T00:00:00Z"
-  },
+  "date": "2014-09-25",
   "shares": 50,
   "amount": 27.59,
   "grossAmount": 0,
@@ -12341,9 +11241,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2014-09-26T00:00:00Z"
-  },
+  "date": "2014-09-26",
   "shares": 300,
   "amount": 53.58,
   "grossAmount": 0,
@@ -12363,9 +11261,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2014-09-30T00:00:00Z"
-  },
+  "date": "2014-09-30",
   "shares": 49,
   "amount": 6.87,
   "grossAmount": 0,
@@ -12385,9 +11281,7 @@
   "type": "Dividend",
   "company": "British American Tobacco",
   "symbol": "BATS.L",
-  "date": {
-    "$date": "2014-09-30T00:00:00Z"
-  },
+  "date": "2014-09-30",
   "shares": 40,
   "amount": 17.45,
   "grossAmount": 0,
@@ -12407,9 +11301,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2014-09-30T00:00:00Z"
-  },
+  "date": "2014-09-30",
   "shares": 77,
   "amount": 13.52,
   "grossAmount": 0,
@@ -12429,9 +11321,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2014-09-30T00:00:00Z"
-  },
+  "date": "2014-09-30",
   "shares": 45,
   "amount": 17.25,
   "grossAmount": 0,
@@ -12451,9 +11341,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2014-10-02T00:00:00Z"
-  },
+  "date": "2014-10-02",
   "shares": 150,
   "amount": 44.05,
   "grossAmount": 0,
@@ -12473,9 +11361,7 @@
   "type": "Dividend",
   "company": "HSBC",
   "symbol": "",
-  "date": {
-    "$date": "2014-10-09T00:00:00Z"
-  },
+  "date": "2014-10-09",
   "shares": 265,
   "amount": 15.09,
   "grossAmount": 0,
@@ -12495,9 +11381,7 @@
   "type": "Dividend",
   "company": "\"Yamana Gold \"",
   "symbol": "AUY",
-  "date": {
-    "$date": "2014-10-14T00:00:00Z"
-  },
+  "date": "2014-10-14",
   "shares": 480,
   "amount": 10.33,
   "grossAmount": 0,
@@ -12517,9 +11401,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2014-10-10T00:00:00Z"
-  },
+  "date": "2014-10-10",
   "shares": 41,
   "amount": 23.26,
   "grossAmount": 0,
@@ -12539,9 +11421,7 @@
   "type": "Dividend",
   "company": "\"Jardine Matheson \"",
   "symbol": "J36.SI",
-  "date": {
-    "$date": "2014-10-15T00:00:00Z"
-  },
+  "date": "2014-10-15",
   "shares": 50,
   "amount": 10.66,
   "grossAmount": 0,
@@ -12561,9 +11441,7 @@
   "type": "Dividend",
   "company": "Great Eagle Holdings",
   "symbol": "0041.HK",
-  "date": {
-    "$date": "2014-10-17T00:00:00Z"
-  },
+  "date": "2014-10-17",
   "shares": 1000,
   "amount": 19.66,
   "grossAmount": 0,
@@ -12583,9 +11461,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2014-10-17T00:00:00Z"
-  },
+  "date": "2014-10-17",
   "shares": 33,
   "amount": 3.99,
   "grossAmount": 0,
@@ -12605,9 +11481,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2014-11-03T00:00:00Z"
-  },
+  "date": "2014-11-03",
   "shares": 25,
   "amount": 8.82,
   "grossAmount": 0,
@@ -12627,9 +11501,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2014-11-06T00:00:00Z"
-  },
+  "date": "2014-11-06",
   "shares": 300,
   "amount": 37.93,
   "grossAmount": 0,
@@ -12649,9 +11521,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2014-11-04T00:00:00Z"
-  },
+  "date": "2014-11-04",
   "shares": 101,
   "amount": 20.83,
   "grossAmount": 0,
@@ -12671,9 +11541,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2014-11-17T00:00:00Z"
-  },
+  "date": "2014-11-17",
   "shares": 46,
   "amount": 17.48,
   "grossAmount": 0,
@@ -12693,9 +11561,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2014-12-01T00:00:00Z"
-  },
+  "date": "2014-12-01",
   "shares": 147,
   "amount": 19.6,
   "grossAmount": 0,
@@ -12715,9 +11581,7 @@
   "type": "Dividend",
   "company": "HSBC",
   "symbol": "",
-  "date": {
-    "$date": "2014-12-10T00:00:00Z"
-  },
+  "date": "2014-12-10",
   "shares": 265,
   "amount": 15.5,
   "grossAmount": 0,
@@ -12737,9 +11601,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2014-12-10T00:00:00Z"
-  },
+  "date": "2014-12-10",
   "shares": 92,
   "amount": 19.35,
   "grossAmount": 0,
@@ -12759,9 +11621,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2014-12-10T00:00:00Z"
-  },
+  "date": "2014-12-10",
   "shares": 46,
   "amount": 19.19,
   "grossAmount": 0,
@@ -12781,9 +11641,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2014-12-11T00:00:00Z"
-  },
+  "date": "2014-12-11",
   "shares": 100,
   "amount": 18.32,
   "grossAmount": 0,
@@ -12803,9 +11661,7 @@
   "type": "Dividend",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2014-12-12T00:00:00Z"
-  },
+  "date": "2014-12-12",
   "shares": 61,
   "amount": 2.27,
   "grossAmount": 0,
@@ -12825,9 +11681,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2014-12-15T00:00:00Z"
-  },
+  "date": "2014-12-15",
   "shares": 123,
   "amount": 3.64,
   "grossAmount": 0,
@@ -12847,9 +11701,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2014-12-22T00:00:00Z"
-  },
+  "date": "2014-12-22",
   "shares": 171,
   "amount": 48.32,
   "grossAmount": 0,
@@ -12869,9 +11721,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2014-12-26T00:00:00Z"
-  },
+  "date": "2014-12-26",
   "shares": 114,
   "amount": 1.72,
   "grossAmount": 0,
@@ -12891,9 +11741,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2014-12-18T00:00:00Z"
-  },
+  "date": "2014-12-18",
   "shares": 48,
   "amount": 5.66,
   "grossAmount": 0,
@@ -12913,9 +11761,7 @@
   "type": "Dividend",
   "company": "Reckitt Benckiser",
   "symbol": "",
-  "date": {
-    "$date": "2014-12-30T00:00:00Z"
-  },
+  "date": "2014-12-30",
   "shares": 50,
   "amount": 76.95,
   "grossAmount": 0,
@@ -12935,9 +11781,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2014-12-31T00:00:00Z"
-  },
+  "date": "2014-12-31",
   "shares": 49,
   "amount": 7.19,
   "grossAmount": 0,
@@ -12957,9 +11801,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2015-01-05T00:00:00Z"
-  },
+  "date": "2015-01-05",
   "shares": 55,
   "amount": 16.48,
   "grossAmount": 0,
@@ -12979,9 +11821,7 @@
   "type": "Dividend",
   "company": "Pepsi",
   "symbol": "",
-  "date": {
-    "$date": "2015-01-07T00:00:00Z"
-  },
+  "date": "2015-01-07",
   "shares": 45,
   "amount": 18.44,
   "grossAmount": 0,
@@ -13001,9 +11841,7 @@
   "type": "Dividend",
   "company": "\"Yamana Gold \"",
   "symbol": "AUY",
-  "date": {
-    "$date": "2015-01-15T00:00:00Z"
-  },
+  "date": "2015-01-15",
   "shares": 480,
   "amount": 4.45,
   "grossAmount": 0,
@@ -13023,9 +11861,7 @@
   "type": "Dividend",
   "company": "Siemens",
   "symbol": "SIE.DE",
-  "date": {
-    "$date": "2015-01-28T00:00:00Z"
-  },
+  "date": "2015-01-28",
   "shares": 31,
   "amount": 75.32,
   "grossAmount": 0,
@@ -13045,9 +11881,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2015-01-09T00:00:00Z"
-  },
+  "date": "2015-01-09",
   "shares": 41,
   "amount": 25.49,
   "grossAmount": 0,
@@ -13067,9 +11901,7 @@
   "type": "Dividend",
   "company": "\"ISHSIII-C.EO CORP.B.EODIS \"",
   "symbol": "IEAC.AS",
-  "date": {
-    "$date": "2015-01-08T00:00:00Z"
-  },
+  "date": "2015-01-08",
   "shares": 490,
   "amount": 633.57,
   "grossAmount": 0,
@@ -13089,9 +11921,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2015-02-02T00:00:00Z"
-  },
+  "date": "2015-02-02",
   "shares": 25,
   "amount": 9.81,
   "grossAmount": 0,
@@ -13111,9 +11941,7 @@
   "type": "Dividend",
   "company": "\"Tai Cheung \"",
   "symbol": "0088.HK",
-  "date": {
-    "$date": "2015-01-08T00:00:00Z"
-  },
+  "date": "2015-01-08",
   "shares": 4000,
   "amount": 34.24,
   "grossAmount": 0,
@@ -13133,9 +11961,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2015-01-16T00:00:00Z"
-  },
+  "date": "2015-01-16",
   "shares": 33,
   "amount": 4.63,
   "grossAmount": 0,
@@ -13155,9 +11981,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2015-02-05T00:00:00Z"
-  },
+  "date": "2015-02-05",
   "shares": 101,
   "amount": 18.31,
   "grossAmount": 0,
@@ -13177,9 +12001,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2015-02-17T00:00:00Z"
-  },
+  "date": "2015-02-17",
   "shares": 46,
   "amount": 16.19,
   "grossAmount": 0,
@@ -13199,9 +12021,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2015-02-17T00:00:00Z"
-  },
+  "date": "2015-02-17",
   "shares": 153,
   "amount": 134.96,
   "grossAmount": 0,
@@ -13221,9 +12041,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2015-03-02T00:00:00Z"
-  },
+  "date": "2015-03-02",
   "shares": 100,
   "amount": 15.95,
   "grossAmount": 0,
@@ -13243,9 +12061,7 @@
   "type": "Dividend",
   "company": "Novartis",
   "symbol": "NOVN.SW",
-  "date": {
-    "$date": "2015-03-05T00:00:00Z"
-  },
+  "date": "2015-03-05",
   "shares": 53,
   "amount": 69.89,
   "grossAmount": 0,
@@ -13265,9 +12081,7 @@
   "type": "Dividend",
   "company": "\"Gold Fields Limited \"",
   "symbol": "GFI",
-  "date": {
-    "$date": "2015-03-09T00:00:00Z"
-  },
+  "date": "2015-03-09",
   "shares": 512,
   "amount": 5.77,
   "grossAmount": 0,
@@ -13287,9 +12101,7 @@
   "type": "Dividend",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2015-03-10T00:00:00Z"
-  },
+  "date": "2015-03-10",
   "shares": 18,
   "amount": 73.07,
   "grossAmount": 0,
@@ -13309,9 +12121,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2015-03-10T00:00:00Z"
-  },
+  "date": "2015-03-10",
   "shares": 35,
   "amount": 16.96,
   "grossAmount": 0,
@@ -13331,9 +12141,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2015-03-11T00:00:00Z"
-  },
+  "date": "2015-03-11",
   "shares": 92,
   "amount": 19.52,
   "grossAmount": 0,
@@ -13353,9 +12161,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2015-03-12T00:00:00Z"
-  },
+  "date": "2015-03-12",
   "shares": 75,
   "amount": 16.23,
   "grossAmount": 0,
@@ -13375,9 +12181,7 @@
   "type": "Dividend",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2015-03-13T00:00:00Z"
-  },
+  "date": "2015-03-13",
   "shares": 61,
   "amount": 2.68,
   "grossAmount": 0,
@@ -13397,9 +12201,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2015-03-16T00:00:00Z"
-  },
+  "date": "2015-03-16",
   "shares": 123,
   "amount": 4.3,
   "grossAmount": 0,
@@ -13419,9 +12221,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2015-03-16T00:00:00Z"
-  },
+  "date": "2015-03-16",
   "shares": 50,
   "amount": 4.22,
   "grossAmount": 0,
@@ -13441,9 +12241,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2015-03-19T00:00:00Z"
-  },
+  "date": "2015-03-19",
   "shares": 6570,
   "amount": 579.8,
   "grossAmount": 0,
@@ -13463,9 +12261,7 @@
   "type": "Dividend",
   "company": "\"White Mountains \"",
   "symbol": "WTM",
-  "date": {
-    "$date": "2015-03-25T00:00:00Z"
-  },
+  "date": "2015-03-25",
   "shares": 3,
   "amount": 2.01,
   "grossAmount": 0,
@@ -13485,9 +12281,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2015-03-26T00:00:00Z"
-  },
+  "date": "2015-03-26",
   "shares": 114,
   "amount": 1.93,
   "grossAmount": 0,
@@ -13507,9 +12301,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2015-03-26T00:00:00Z"
-  },
+  "date": "2015-03-26",
   "shares": 48,
   "amount": 6.53,
   "grossAmount": 0,
@@ -13529,9 +12321,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2015-03-20T00:00:00Z"
-  },
+  "date": "2015-03-20",
   "shares": 171,
   "amount": 55.12,
   "grossAmount": 0,
@@ -13551,9 +12341,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2015-03-27T00:00:00Z"
-  },
+  "date": "2015-03-27",
   "shares": 300,
   "amount": 53.14,
   "grossAmount": 0,
@@ -13573,9 +12361,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2015-03-31T00:00:00Z"
-  },
+  "date": "2015-03-31",
   "shares": 77,
   "amount": 13.31,
   "grossAmount": 0,
@@ -13595,9 +12381,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2015-03-31T00:00:00Z"
-  },
+  "date": "2015-03-31",
   "shares": 49,
   "amount": 8.12,
   "grossAmount": 0,
@@ -13617,9 +12401,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2015-04-06T00:00:00Z"
-  },
+  "date": "2015-04-06",
   "shares": 40,
   "amount": 13.41,
   "grossAmount": 0,
@@ -13639,9 +12421,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2015-04-07T00:00:00Z"
-  },
+  "date": "2015-04-07",
   "shares": 150,
   "amount": 32.51,
   "grossAmount": 0,
@@ -13661,9 +12441,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2015-04-10T00:00:00Z"
-  },
+  "date": "2015-04-10",
   "shares": 41,
   "amount": 28.37,
   "grossAmount": 0,
@@ -13683,9 +12461,7 @@
   "type": "Dividend",
   "company": "\"Yamana Gold \"",
   "symbol": "AUY",
-  "date": {
-    "$date": "2015-04-14T00:00:00Z"
-  },
+  "date": "2015-04-14",
   "shares": 480,
   "amount": 5.15,
   "grossAmount": 0,
@@ -13705,9 +12481,7 @@
   "type": "Dividend",
   "company": "ISHSVI-G.C.BD EO H DIST",
   "symbol": "CRPH.L",
-  "date": {
-    "$date": "2015-04-16T00:00:00Z"
-  },
+  "date": "2015-04-16",
   "shares": 610,
   "amount": 640.19,
   "grossAmount": 0,
@@ -13727,9 +12501,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2015-04-17T00:00:00Z"
-  },
+  "date": "2015-04-17",
   "shares": 33,
   "amount": 4.93,
   "grossAmount": 0,
@@ -13749,9 +12521,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2015-04-15T00:00:00Z"
-  },
+  "date": "2015-04-15",
   "shares": 220,
   "amount": 57.31,
   "grossAmount": 0,
@@ -13771,9 +12541,7 @@
   "type": "Dividend",
   "company": "Lundberg",
   "symbol": "LUND-B.ST",
-  "date": {
-    "$date": "2015-04-22T00:00:00Z"
-  },
+  "date": "2015-04-22",
   "shares": 55,
   "amount": 21.76,
   "grossAmount": 0,
@@ -13793,9 +12561,7 @@
   "type": "Dividend",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2015-04-22T00:00:00Z"
-  },
+  "date": "2015-04-22",
   "shares": 48,
   "amount": 55.1,
   "grossAmount": 0,
@@ -13815,9 +12581,7 @@
   "type": "Dividend",
   "company": "Munich Re",
   "symbol": "MUV2.DE",
-  "date": {
-    "$date": "2015-04-24T00:00:00Z"
-  },
+  "date": "2015-04-24",
   "shares": 20,
   "amount": 111.61,
   "grossAmount": 0,
@@ -13837,9 +12601,7 @@
   "type": "Dividend",
   "company": "Orkla",
   "symbol": "OKL.F",
-  "date": {
-    "$date": "2015-04-28T00:00:00Z"
-  },
+  "date": "2015-04-28",
   "shares": 360,
   "amount": 50.26,
   "grossAmount": 0,
@@ -13859,9 +12621,7 @@
   "type": "Dividend",
   "company": "HSBC",
   "symbol": "",
-  "date": {
-    "$date": "2015-04-30T00:00:00Z"
-  },
+  "date": "2015-04-30",
   "shares": 265,
   "amount": 34.98,
   "grossAmount": 0,
@@ -13881,9 +12641,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2015-05-01T00:00:00Z"
-  },
+  "date": "2015-05-01",
   "shares": 25,
   "amount": 9.91,
   "grossAmount": 0,
@@ -13903,9 +12661,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2015-05-04T00:00:00Z"
-  },
+  "date": "2015-05-04",
   "shares": 101,
   "amount": 25.22,
   "grossAmount": 0,
@@ -13925,9 +12681,7 @@
   "type": "Dividend",
   "company": "GBL",
   "symbol": "GBLB.BR",
-  "date": {
-    "$date": "2015-05-07T00:00:00Z"
-  },
+  "date": "2015-05-07",
   "shares": 37,
   "amount": 65.87,
   "grossAmount": 0,
@@ -13947,9 +12701,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2015-05-06T00:00:00Z"
-  },
+  "date": "2015-05-06",
   "shares": 70,
   "amount": 38.24,
   "grossAmount": 0,
@@ -13969,9 +12721,7 @@
   "type": "Dividend",
   "company": "\"Jardine Matheson \"",
   "symbol": "J36.SI",
-  "date": {
-    "$date": "2015-05-13T00:00:00Z"
-  },
+  "date": "2015-05-13",
   "shares": 50,
   "amount": 33.59,
   "grossAmount": 0,
@@ -13991,9 +12741,7 @@
   "type": "Dividend",
   "company": "British American Tobacco",
   "symbol": "BATS.L",
-  "date": {
-    "$date": "2015-05-07T00:00:00Z"
-  },
+  "date": "2015-05-07",
   "shares": 40,
   "amount": 39.28,
   "grossAmount": 0,
@@ -14013,9 +12761,7 @@
   "type": "Dividend",
   "company": "Standard Chartered",
   "symbol": "2888.HK",
-  "date": {
-    "$date": "2015-05-14T00:00:00Z"
-  },
+  "date": "2015-05-14",
   "shares": 175,
   "amount": 64.15,
   "grossAmount": 0,
@@ -14035,9 +12781,7 @@
   "type": "Dividend",
   "company": "Procter & Gamble",
   "symbol": "",
-  "date": {
-    "$date": "2015-05-15T00:00:00Z"
-  },
+  "date": "2015-05-15",
   "shares": 46,
   "amount": 19.75,
   "grossAmount": 0,
@@ -14057,9 +12801,7 @@
   "type": "Dividend",
   "company": "Sofina",
   "symbol": "SOF.BR",
-  "date": {
-    "$date": "2015-05-18T00:00:00Z"
-  },
+  "date": "2015-05-18",
   "shares": 20,
   "amount": 29.1,
   "grossAmount": 0,
@@ -14079,9 +12821,7 @@
   "type": "Dividend",
   "company": "\"Fresnillo \"",
   "symbol": "FRES.L",
-  "date": {
-    "$date": "2015-05-22T00:00:00Z"
-  },
+  "date": "2015-05-22",
   "shares": 333,
   "amount": 6.68,
   "grossAmount": 0,
@@ -14101,9 +12841,7 @@
   "type": "Dividend",
   "company": "\"Vornado Realty Trust \"",
   "symbol": "VNO",
-  "date": {
-    "$date": "2015-05-22T00:00:00Z"
-  },
+  "date": "2015-05-22",
   "shares": 45,
   "amount": 18.71,
   "grossAmount": 0,
@@ -14123,9 +12861,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2015-05-20T00:00:00Z"
-  },
+  "date": "2015-05-20",
   "shares": 143,
   "amount": 101.89,
   "grossAmount": 0,
@@ -14145,9 +12881,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2015-06-01T00:00:00Z"
-  },
+  "date": "2015-06-01",
   "shares": 100,
   "amount": 16.01,
   "grossAmount": 0,
@@ -14167,9 +12901,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2015-06-01T00:00:00Z"
-  },
+  "date": "2015-06-01",
   "shares": 40,
   "amount": 13.09,
   "grossAmount": 0,
@@ -14189,9 +12921,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2015-06-03T00:00:00Z"
-  },
+  "date": "2015-06-03",
   "shares": 92,
   "amount": 20.52,
   "grossAmount": 0,
@@ -14211,9 +12941,7 @@
   "type": "Dividend",
   "company": "\"Swatch \"",
   "symbol": "UHRN.SW",
-  "date": {
-    "$date": "2015-06-03T00:00:00Z"
-  },
+  "date": "2015-06-03",
   "shares": 27,
   "amount": 20.87,
   "grossAmount": 0,
@@ -14233,9 +12961,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2015-06-03T00:00:00Z"
-  },
+  "date": "2015-06-03",
   "shares": 220,
   "amount": 1801.8,
   "grossAmount": 0,
@@ -14255,9 +12981,7 @@
   "type": "Dividend",
   "company": "Aker",
   "symbol": "FKM.F",
-  "date": {
-    "$date": "2015-06-05T00:00:00Z"
-  },
+  "date": "2015-06-05",
   "shares": 110,
   "amount": 58.24,
   "grossAmount": 0,
@@ -14277,9 +13001,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2015-06-10T00:00:00Z"
-  },
+  "date": "2015-06-10",
   "shares": 35,
   "amount": 17.12,
   "grossAmount": 0,
@@ -14299,9 +13021,7 @@
   "type": "Dividend",
   "company": "Loews",
   "symbol": "",
-  "date": {
-    "$date": "2015-06-12T00:00:00Z"
-  },
+  "date": "2015-06-12",
   "shares": 61,
   "amount": 2.52,
   "grossAmount": 0,
@@ -14321,9 +13041,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2015-06-11T00:00:00Z"
-  },
+  "date": "2015-06-11",
   "shares": 75,
   "amount": 15.18,
   "grossAmount": 0,
@@ -14343,9 +13061,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2015-06-15T00:00:00Z"
-  },
+  "date": "2015-06-15",
   "shares": 123,
   "amount": 4.03,
   "grossAmount": 0,
@@ -14365,9 +13081,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2015-06-15T00:00:00Z"
-  },
+  "date": "2015-06-15",
   "shares": 50,
   "amount": 3.95,
   "grossAmount": 0,
@@ -14387,9 +13101,7 @@
   "type": "Dividend",
   "company": "Deutsche Wohnen",
   "symbol": "DWNI.DE",
-  "date": {
-    "$date": "2015-06-15T00:00:00Z"
-  },
+  "date": "2015-06-15",
   "shares": 110,
   "amount": 48.4,
   "grossAmount": 0,
@@ -14409,9 +13121,7 @@
   "type": "Dividend",
   "company": "Great Eagle Holdings",
   "symbol": "0041.HK",
-  "date": {
-    "$date": "2015-06-16T00:00:00Z"
-  },
+  "date": "2015-06-16",
   "shares": 1000,
   "amount": 38.75,
   "grossAmount": 0,
@@ -14431,9 +13141,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2015-06-18T00:00:00Z"
-  },
+  "date": "2015-06-18",
   "shares": 6570,
   "amount": 1081.45,
   "grossAmount": 0,
@@ -14453,9 +13161,7 @@
   "type": "Dividend",
   "company": "First Pacific",
   "symbol": "0142.HK",
-  "date": {
-    "$date": "2015-06-24T00:00:00Z"
-  },
+  "date": "2015-06-24",
   "shares": 4000,
   "amount": 42.44,
   "grossAmount": 0,
@@ -14475,9 +13181,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2015-06-22T00:00:00Z"
-  },
+  "date": "2015-06-22",
   "shares": 171,
   "amount": 52.95,
   "grossAmount": 0,
@@ -14497,9 +13201,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2015-06-25T00:00:00Z"
-  },
+  "date": "2015-06-25",
   "shares": 114,
   "amount": 1.87,
   "grossAmount": 0,
@@ -14519,9 +13221,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2015-06-25T00:00:00Z"
-  },
+  "date": "2015-06-25",
   "shares": 48,
   "amount": 6.51,
   "grossAmount": 0,
@@ -14541,9 +13241,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2015-06-26T00:00:00Z"
-  },
+  "date": "2015-06-26",
   "shares": 300,
   "amount": 97.48,
   "grossAmount": 0,
@@ -14563,9 +13261,7 @@
   "type": "Dividend",
   "company": "Bollore",
   "symbol": "BOL.PA",
-  "date": {
-    "$date": "2015-06-29T00:00:00Z"
-  },
+  "date": "2015-06-29",
   "shares": 500,
   "amount": 11.77,
   "grossAmount": 0,
@@ -14585,9 +13281,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2015-06-30T00:00:00Z"
-  },
+  "date": "2015-06-30",
   "shares": 67,
   "amount": 28.04,
   "grossAmount": 0,
@@ -14607,9 +13301,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2015-06-30T00:00:00Z"
-  },
+  "date": "2015-06-30",
   "shares": 163,
   "amount": 26.79,
   "grossAmount": 0,
@@ -14629,9 +13321,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2015-06-30T00:00:00Z"
-  },
+  "date": "2015-06-30",
   "shares": 49,
   "amount": 7.74,
   "grossAmount": 0,
@@ -14651,9 +13341,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2015-06-30T00:00:00Z"
-  },
+  "date": "2015-06-30",
   "shares": 130.5,
   "amount": 6.87,
   "grossAmount": 0,
@@ -14673,9 +13361,7 @@
   "type": "Dividend",
   "company": "HSBC",
   "symbol": "",
-  "date": {
-    "$date": "2015-07-08T00:00:00Z"
-  },
+  "date": "2015-07-08",
   "shares": 265,
   "amount": 17.22,
   "grossAmount": 0,
@@ -14695,9 +13381,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2015-07-10T00:00:00Z"
-  },
+  "date": "2015-07-10",
   "shares": 41,
   "amount": 26.71,
   "grossAmount": 0,
@@ -14717,9 +13401,7 @@
   "type": "Dividend",
   "company": "\"Melco International Development \"",
   "symbol": "0200.HK",
-  "date": {
-    "$date": "2015-07-06T00:00:00Z"
-  },
+  "date": "2015-07-06",
   "shares": 2000,
   "amount": 12.52,
   "grossAmount": 0,
@@ -14739,9 +13421,7 @@
   "type": "Dividend",
   "company": "\"Yamana Gold \"",
   "symbol": "AUY",
-  "date": {
-    "$date": "2015-07-14T00:00:00Z"
-  },
+  "date": "2015-07-14",
   "shares": 480,
   "amount": 4.71,
   "grossAmount": 0,
@@ -14761,9 +13441,7 @@
   "type": "Dividend",
   "company": "First Industrial Realty Trust",
   "symbol": "FR",
-  "date": {
-    "$date": "2015-07-20T00:00:00Z"
-  },
+  "date": "2015-07-20",
   "shares": 150,
   "amount": 12.98,
   "grossAmount": 0,
@@ -14783,9 +13461,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2015-07-17T00:00:00Z"
-  },
+  "date": "2015-07-17",
   "shares": 33,
   "amount": 4.92,
   "grossAmount": 0,
@@ -14805,9 +13481,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2015-07-31T00:00:00Z"
-  },
+  "date": "2015-07-31",
   "shares": 101,
   "amount": 25.74,
   "grossAmount": 0,
@@ -14827,9 +13501,7 @@
   "type": "Dividend",
   "company": "\"ISHSIII-C.EO CORP.B.EODIS \"",
   "symbol": "IEAC.AS",
-  "date": {
-    "$date": "2015-07-16T00:00:00Z"
-  },
+  "date": "2015-07-16",
   "shares": 490,
   "amount": 400.67,
   "grossAmount": 0,
@@ -14849,9 +13521,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2015-08-03T00:00:00Z"
-  },
+  "date": "2015-08-03",
   "shares": 25,
   "amount": 10.05,
   "grossAmount": 0,
@@ -14871,9 +13541,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2015-08-10T00:00:00Z"
-  },
+  "date": "2015-08-10",
   "shares": 24,
   "amount": 2.6,
   "grossAmount": 0,
@@ -14893,9 +13561,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2015-08-12T00:00:00Z"
-  },
+  "date": "2015-08-12",
   "shares": 70,
   "amount": 22.74,
   "grossAmount": 0,
@@ -14915,9 +13581,7 @@
   "type": "Dividend",
   "company": "\"Dexus Property \"",
   "symbol": "DXS.AX",
-  "date": {
-    "$date": "2015-08-31T00:00:00Z"
-  },
+  "date": "2015-08-31",
   "shares": 555,
   "amount": 47.06,
   "grossAmount": 0,
@@ -14937,9 +13601,7 @@
   "type": "Dividend",
   "company": "\"Vornado Realty Trust \"",
   "symbol": "VNO",
-  "date": {
-    "$date": "2015-08-21T00:00:00Z"
-  },
+  "date": "2015-08-21",
   "shares": 45,
   "amount": 18.49,
   "grossAmount": 0,
@@ -14959,9 +13621,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2015-09-01T00:00:00Z"
-  },
+  "date": "2015-09-01",
   "shares": 100,
   "amount": 15.66,
   "grossAmount": 0,
@@ -14981,9 +13641,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2015-09-03T00:00:00Z"
-  },
+  "date": "2015-09-03",
   "shares": 68,
   "amount": 4.69,
   "grossAmount": 0,
@@ -15003,9 +13661,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2015-09-08T00:00:00Z"
-  },
+  "date": "2015-09-08",
   "shares": 40,
   "amount": 12.91,
   "grossAmount": 0,
@@ -15025,9 +13681,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2015-09-08T00:00:00Z"
-  },
+  "date": "2015-09-08",
   "shares": 35,
   "amount": 17.28,
   "grossAmount": 0,
@@ -15047,9 +13701,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2015-09-09T00:00:00Z"
-  },
+  "date": "2015-09-09",
   "shares": 92,
   "amount": 20.52,
   "grossAmount": 0,
@@ -15069,9 +13721,7 @@
   "type": "Dividend",
   "company": "\"Fresnillo \"",
   "symbol": "FRES.L",
-  "date": {
-    "$date": "2015-09-10T00:00:00Z"
-  },
+  "date": "2015-09-10",
   "shares": 333,
   "amount": 4.39,
   "grossAmount": 0,
@@ -15091,9 +13741,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2015-09-10T00:00:00Z"
-  },
+  "date": "2015-09-10",
   "shares": 75,
   "amount": 15.28,
   "grossAmount": 0,
@@ -15113,9 +13761,7 @@
   "type": "Dividend",
   "company": "\"City Developments \"",
   "symbol": "C09.SI",
-  "date": {
-    "$date": "2015-09-10T00:00:00Z"
-  },
+  "date": "2015-09-10",
   "shares": 420,
   "amount": 7.56,
   "grossAmount": 0,
@@ -15135,9 +13781,7 @@
   "type": "Dividend",
   "company": "\"Gold Fields Limited \"",
   "symbol": "GFI",
-  "date": {
-    "$date": "2015-09-14T00:00:00Z"
-  },
+  "date": "2015-09-14",
   "shares": 512,
   "amount": 0.99,
   "grossAmount": 0,
@@ -15157,9 +13801,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2015-09-15T00:00:00Z"
-  },
+  "date": "2015-09-15",
   "shares": 280,
   "amount": 3.65,
   "grossAmount": 0,
@@ -15179,9 +13821,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2015-09-17T00:00:00Z"
-  },
+  "date": "2015-09-17",
   "shares": 6570,
   "amount": 652.41,
   "grossAmount": 0,
@@ -15201,9 +13841,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2015-09-15T00:00:00Z"
-  },
+  "date": "2015-09-15",
   "shares": 50,
   "amount": 3.91,
   "grossAmount": 0,
@@ -15223,9 +13861,7 @@
   "type": "Dividend",
   "company": "\"Tai Cheung \"",
   "symbol": "0088.HK",
-  "date": {
-    "$date": "2015-09-17T00:00:00Z"
-  },
+  "date": "2015-09-17",
   "shares": 4000,
   "amount": 62.23,
   "grossAmount": 0,
@@ -15245,9 +13881,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2015-09-21T00:00:00Z"
-  },
+  "date": "2015-09-21",
   "shares": 171,
   "amount": 53.36,
   "grossAmount": 0,
@@ -15267,9 +13901,7 @@
   "type": "Dividend",
   "company": "\"Compagnie Financiere Richemont SA \"",
   "symbol": "CFR.SW",
-  "date": {
-    "$date": "2015-09-22T00:00:00Z"
-  },
+  "date": "2015-09-22",
   "shares": 31,
   "amount": 24.47,
   "grossAmount": 0,
@@ -15289,9 +13921,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2015-09-24T00:00:00Z"
-  },
+  "date": "2015-09-24",
   "shares": 114,
   "amount": 1.87,
   "grossAmount": 0,
@@ -15311,9 +13941,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2015-09-24T00:00:00Z"
-  },
+  "date": "2015-09-24",
   "shares": 48,
   "amount": 6.58,
   "grossAmount": 0,
@@ -15333,9 +13961,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2015-09-25T00:00:00Z"
-  },
+  "date": "2015-09-25",
   "shares": 300,
   "amount": 62.5,
   "grossAmount": 0,
@@ -15355,9 +13981,7 @@
   "type": "Dividend",
   "company": "\"Weyerhaeuser \"",
   "symbol": "WY",
-  "date": {
-    "$date": "2015-09-25T00:00:00Z"
-  },
+  "date": "2015-09-25",
   "shares": 75,
   "amount": 15.32,
   "grossAmount": 0,
@@ -15377,9 +14001,7 @@
   "type": "Dividend",
   "company": "First Pacific",
   "symbol": "0142.HK",
-  "date": {
-    "$date": "2015-09-25T00:00:00Z"
-  },
+  "date": "2015-09-25",
   "shares": 4000,
   "amount": 26.56,
   "grossAmount": 0,
@@ -15399,9 +14021,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2015-09-30T00:00:00Z"
-  },
+  "date": "2015-09-30",
   "shares": 163,
   "amount": 26.7,
   "grossAmount": 0,
@@ -15421,9 +14041,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2015-09-30T00:00:00Z"
-  },
+  "date": "2015-09-30",
   "shares": 67,
   "amount": 13.93,
   "grossAmount": 0,
@@ -15443,9 +14061,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2015-09-30T00:00:00Z"
-  },
+  "date": "2015-09-30",
   "shares": 49,
   "amount": 7.71,
   "grossAmount": 0,
@@ -15465,9 +14081,7 @@
   "type": "Dividend",
   "company": "British American Tobacco",
   "symbol": "BATS.L",
-  "date": {
-    "$date": "2015-09-30T00:00:00Z"
-  },
+  "date": "2015-09-30",
   "shares": 40,
   "amount": 19.32,
   "grossAmount": 0,
@@ -15487,9 +14101,7 @@
   "type": "Dividend",
   "company": "\"Melco International Development \"",
   "symbol": "0200.HK",
-  "date": {
-    "$date": "2015-09-30T00:00:00Z"
-  },
+  "date": "2015-09-30",
   "shares": 2000,
   "amount": 2.48,
   "grossAmount": 0,
@@ -15509,9 +14121,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2015-09-30T00:00:00Z"
-  },
+  "date": "2015-09-30",
   "shares": 130.5,
   "amount": 6.86,
   "grossAmount": 0,
@@ -15531,9 +14141,7 @@
   "type": "Dividend",
   "company": "Bollore",
   "symbol": "BOL.PA",
-  "date": {
-    "$date": "2015-10-02T00:00:00Z"
-  },
+  "date": "2015-10-02",
   "shares": 500,
   "amount": 5.89,
   "grossAmount": 0,
@@ -15553,9 +14161,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2015-10-08T00:00:00Z"
-  },
+  "date": "2015-10-08",
   "shares": 150,
   "amount": 51,
   "grossAmount": 0,
@@ -15575,9 +14181,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2015-10-06T00:00:00Z"
-  },
+  "date": "2015-10-06",
   "shares": 220,
   "amount": 12.76,
   "grossAmount": 0,
@@ -15597,9 +14201,7 @@
   "type": "Dividend",
   "company": "\"Yamana Gold \"",
   "symbol": "AUY",
-  "date": {
-    "$date": "2015-10-14T00:00:00Z"
-  },
+  "date": "2015-10-14",
   "shares": 480,
   "amount": 4.82,
   "grossAmount": 0,
@@ -15619,9 +14221,7 @@
   "type": "Dividend",
   "company": "\"Jardine Matheson \"",
   "symbol": "J36.SI",
-  "date": {
-    "$date": "2015-10-14T00:00:00Z"
-  },
+  "date": "2015-10-14",
   "shares": 50,
   "amount": 11.92,
   "grossAmount": 0,
@@ -15641,9 +14241,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2015-10-14T00:00:00Z"
-  },
+  "date": "2015-10-14",
   "shares": 41,
   "amount": 26.26,
   "grossAmount": 0,
@@ -15663,9 +14261,7 @@
   "type": "Dividend",
   "company": "Great Eagle Holdings",
   "symbol": "0041.HK",
-  "date": {
-    "$date": "2015-10-16T00:00:00Z"
-  },
+  "date": "2015-10-16",
   "shares": 1000,
   "amount": 21.95,
   "grossAmount": 0,
@@ -15685,9 +14281,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2015-10-16T00:00:00Z"
-  },
+  "date": "2015-10-16",
   "shares": 33,
   "amount": 4.71,
   "grossAmount": 0,
@@ -15707,9 +14301,7 @@
   "type": "Dividend",
   "company": "Standard Chartered",
   "symbol": "2888.HK",
-  "date": {
-    "$date": "2015-10-19T00:00:00Z"
-  },
+  "date": "2015-10-19",
   "shares": 175,
   "amount": 16.09,
   "grossAmount": 0,
@@ -15729,9 +14321,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2015-11-02T00:00:00Z"
-  },
+  "date": "2015-11-02",
   "shares": 25,
   "amount": 10.02,
   "grossAmount": 0,
@@ -15751,9 +14341,7 @@
   "type": "Dividend",
   "company": "First Industrial Realty Trust",
   "symbol": "FR",
-  "date": {
-    "$date": "2015-10-19T00:00:00Z"
-  },
+  "date": "2015-10-19",
   "shares": 150,
   "amount": 12.41,
   "grossAmount": 0,
@@ -15773,9 +14361,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2015-11-03T00:00:00Z"
-  },
+  "date": "2015-11-03",
   "shares": 101,
   "amount": 25.82,
   "grossAmount": 0,
@@ -15795,9 +14381,7 @@
   "type": "Dividend",
   "company": "Wereldhave",
   "symbol": "WER.SG",
-  "date": {
-    "$date": "2015-11-06T00:00:00Z"
-  },
+  "date": "2015-11-06",
   "shares": 58,
   "amount": 64.22,
   "grossAmount": 0,
@@ -15817,9 +14401,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2015-12-01T00:00:00Z"
-  },
+  "date": "2015-12-01",
   "shares": 100,
   "amount": 16.64,
   "grossAmount": 0,
@@ -15839,9 +14421,7 @@
   "type": "Dividend",
   "company": "\"Vornado Realty Trust \"",
   "symbol": "VNO",
-  "date": {
-    "$date": "2015-11-23T00:00:00Z"
-  },
+  "date": "2015-11-23",
   "shares": 45,
   "amount": 19.67,
   "grossAmount": 0,
@@ -15861,9 +14441,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2015-11-09T00:00:00Z"
-  },
+  "date": "2015-11-09",
   "shares": 24,
   "amount": 2.63,
   "grossAmount": 0,
@@ -15883,9 +14461,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2015-12-03T00:00:00Z"
-  },
+  "date": "2015-12-03",
   "shares": 68,
   "amount": 4.99,
   "grossAmount": 0,
@@ -15905,9 +14481,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2015-12-09T00:00:00Z"
-  },
+  "date": "2015-12-09",
   "shares": 92,
   "amount": 20.52,
   "grossAmount": 0,
@@ -15927,9 +14501,7 @@
   "type": "Dividend",
   "company": "Standard Chartered",
   "symbol": "2888.HK",
-  "date": {
-    "$date": "2015-12-10T00:00:00Z"
-  },
+  "date": "2015-12-10",
   "shares": 175,
   "amount": 23.4,
   "grossAmount": 0,
@@ -15949,9 +14521,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2015-12-08T00:00:00Z"
-  },
+  "date": "2015-12-08",
   "shares": 35,
   "amount": 17.79,
   "grossAmount": 0,
@@ -15971,9 +14541,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2015-12-10T00:00:00Z"
-  },
+  "date": "2015-12-10",
   "shares": 75,
   "amount": 18.11,
   "grossAmount": 0,
@@ -15993,9 +14561,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2015-12-15T00:00:00Z"
-  },
+  "date": "2015-12-15",
   "shares": 50,
   "amount": 4.02,
   "grossAmount": 0,
@@ -16015,9 +14581,7 @@
   "type": "Dividend",
   "company": "\"Agnico-Eagle Mines Ltd. \"",
   "symbol": "AEM",
-  "date": {
-    "$date": "2015-12-15T00:00:00Z"
-  },
+  "date": "2015-12-15",
   "shares": 128,
   "amount": 6.89,
   "grossAmount": 0,
@@ -16037,9 +14601,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2015-12-17T00:00:00Z"
-  },
+  "date": "2015-12-17",
   "shares": 48,
   "amount": 6.5,
   "grossAmount": 0,
@@ -16059,9 +14621,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2015-12-15T00:00:00Z"
-  },
+  "date": "2015-12-15",
   "shares": 280,
   "amount": 3.81,
   "grossAmount": 0,
@@ -16081,9 +14641,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2015-12-18T00:00:00Z"
-  },
+  "date": "2015-12-18",
   "shares": 171,
   "amount": 54.26,
   "grossAmount": 0,
@@ -16103,9 +14661,7 @@
   "type": "Dividend",
   "company": "KWS Saat",
   "symbol": "KWS.DE",
-  "date": {
-    "$date": "2015-12-18T00:00:00Z"
-  },
+  "date": "2015-12-18",
   "shares": 7,
   "amount": 15.13,
   "grossAmount": 0,
@@ -16125,9 +14681,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2015-12-28T00:00:00Z"
-  },
+  "date": "2015-12-28",
   "shares": 114,
   "amount": 1.92,
   "grossAmount": 0,
@@ -16147,9 +14701,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2015-12-29T00:00:00Z"
-  },
+  "date": "2015-12-29",
   "shares": 300,
   "amount": 54.1,
   "grossAmount": 0,
@@ -16169,9 +14721,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2015-12-30T00:00:00Z"
-  },
+  "date": "2015-12-30",
   "shares": 6570,
   "amount": 942.13,
   "grossAmount": 0,
@@ -16191,9 +14741,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2015-12-31T00:00:00Z"
-  },
+  "date": "2015-12-31",
   "shares": 163,
   "amount": 27.44,
   "grossAmount": 0,
@@ -16213,9 +14761,7 @@
   "type": "Dividend",
   "company": "Imperial Tobacco",
   "symbol": "",
-  "date": {
-    "$date": "2015-12-31T00:00:00Z"
-  },
+  "date": "2015-12-31",
   "shares": 67,
   "amount": 31.92,
   "grossAmount": 0,
@@ -16235,9 +14781,7 @@
   "type": "Dividend",
   "company": "\"Devon \"",
   "symbol": "DVN",
-  "date": {
-    "$date": "2015-12-31T00:00:00Z"
-  },
+  "date": "2015-12-31",
   "shares": 49,
   "amount": 7.93,
   "grossAmount": 0,
@@ -16257,9 +14801,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2015-12-31T00:00:00Z"
-  },
+  "date": "2015-12-31",
   "shares": 130.5,
   "amount": 6.74,
   "grossAmount": 0,
@@ -16279,9 +14821,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2016-01-04T00:00:00Z"
-  },
+  "date": "2016-01-04",
   "shares": 40,
   "amount": 13.21,
   "grossAmount": 0,
@@ -16301,9 +14841,7 @@
   "type": "Dividend",
   "company": "\"Tai Cheung \"",
   "symbol": "0088.HK",
-  "date": {
-    "$date": "2016-01-07T00:00:00Z"
-  },
+  "date": "2016-01-07",
   "shares": 4000,
   "amount": 37.68,
   "grossAmount": 0,
@@ -16323,9 +14861,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2016-01-08T00:00:00Z"
-  },
+  "date": "2016-01-08",
   "shares": 41,
   "amount": 27.64,
   "grossAmount": 0,
@@ -16345,9 +14881,7 @@
   "type": "Dividend",
   "company": "\"Yamana Gold \"",
   "symbol": "AUY",
-  "date": {
-    "$date": "2016-01-14T00:00:00Z"
-  },
+  "date": "2016-01-14",
   "shares": 480,
   "amount": 4.63,
   "grossAmount": 0,
@@ -16367,9 +14901,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2016-01-22T00:00:00Z"
-  },
+  "date": "2016-01-22",
   "shares": 76,
   "amount": 11.86,
   "grossAmount": 0,
@@ -16389,9 +14921,7 @@
   "type": "Dividend",
   "company": "First Industrial Realty Trust",
   "symbol": "FR",
-  "date": {
-    "$date": "2016-01-19T00:00:00Z"
-  },
+  "date": "2016-01-19",
   "shares": 150,
   "amount": 12.95,
   "grossAmount": 0,
@@ -16411,9 +14941,7 @@
   "type": "Dividend",
   "company": "\"ISHSIII-C.EO CORP.B.EODIS \"",
   "symbol": "IEAC.AS",
-  "date": {
-    "$date": "2016-01-27T00:00:00Z"
-  },
+  "date": "2016-01-27",
   "shares": 490,
   "amount": 549.29,
   "grossAmount": 0,
@@ -16433,9 +14961,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2016-02-01T00:00:00Z"
-  },
+  "date": "2016-02-01",
   "shares": 25,
   "amount": 11.7,
   "grossAmount": 0,
@@ -16455,9 +14981,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2016-02-04T00:00:00Z"
-  },
+  "date": "2016-02-04",
   "shares": 101,
   "amount": 25.28,
   "grossAmount": 0,
@@ -16477,9 +15001,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2016-02-09T00:00:00Z"
-  },
+  "date": "2016-02-09",
   "shares": 24,
   "amount": 3,
   "grossAmount": 0,
@@ -16499,9 +15021,7 @@
   "type": "Dividend",
   "company": "\"Dexus Property \"",
   "symbol": "DXS.AX",
-  "date": {
-    "$date": "2016-02-29T00:00:00Z"
-  },
+  "date": "2016-02-29",
   "shares": 555,
   "amount": 52.47,
   "grossAmount": 0,
@@ -16521,9 +15041,7 @@
   "type": "Dividend",
   "company": "\"Vornado Realty Trust \"",
   "symbol": "VNO",
-  "date": {
-    "$date": "2016-02-17T00:00:00Z"
-  },
+  "date": "2016-02-17",
   "shares": 45,
   "amount": 18.66,
   "grossAmount": 0,
@@ -16543,9 +15061,7 @@
   "type": "Dividend",
   "company": "Novartis",
   "symbol": "NOVN.SW",
-  "date": {
-    "$date": "2016-02-29T00:00:00Z"
-  },
+  "date": "2016-02-29",
   "shares": 53,
   "amount": 74.75,
   "grossAmount": 0,
@@ -16565,9 +15081,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2016-03-01T00:00:00Z"
-  },
+  "date": "2016-03-01",
   "shares": 100,
   "amount": 17.62,
   "grossAmount": 0,
@@ -16587,9 +15101,7 @@
   "type": "Dividend",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2016-03-07T00:00:00Z"
-  },
+  "date": "2016-03-07",
   "shares": 18,
   "amount": 71.46,
   "grossAmount": 0,
@@ -16609,9 +15121,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2016-03-03T00:00:00Z"
-  },
+  "date": "2016-03-03",
   "shares": 68,
   "amount": 4.84,
   "grossAmount": 0,
@@ -16631,9 +15141,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2016-03-09T00:00:00Z"
-  },
+  "date": "2016-03-09",
   "shares": 92,
   "amount": 20.52,
   "grossAmount": 0,
@@ -16653,9 +15161,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2016-03-08T00:00:00Z"
-  },
+  "date": "2016-03-08",
   "shares": 35,
   "amount": 17.58,
   "grossAmount": 0,
@@ -16675,9 +15181,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2016-03-10T00:00:00Z"
-  },
+  "date": "2016-03-10",
   "shares": 75,
   "amount": 18.1,
   "grossAmount": 0,
@@ -16697,9 +15201,7 @@
   "type": "Dividend",
   "company": "\"Gold Fields Limited \"",
   "symbol": "GFI",
-  "date": {
-    "$date": "2016-03-14T00:00:00Z"
-  },
+  "date": "2016-03-14",
   "shares": 512,
   "amount": 4.63,
   "grossAmount": 0,
@@ -16719,9 +15221,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2016-03-15T00:00:00Z"
-  },
+  "date": "2016-03-15",
   "shares": 50,
   "amount": 4.32,
   "grossAmount": 0,
@@ -16741,9 +15241,7 @@
   "type": "Dividend",
   "company": "\"Agnico-Eagle Mines Ltd. \"",
   "symbol": "AEM",
-  "date": {
-    "$date": "2016-03-15T00:00:00Z"
-  },
+  "date": "2016-03-15",
   "shares": 128,
   "amount": 6.8,
   "grossAmount": 0,
@@ -16763,9 +15261,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2016-03-15T00:00:00Z"
-  },
+  "date": "2016-03-15",
   "shares": 280,
   "amount": 3.65,
   "grossAmount": 0,
@@ -16785,9 +15281,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2016-03-24T00:00:00Z"
-  },
+  "date": "2016-03-24",
   "shares": 114,
   "amount": 1.88,
   "grossAmount": 0,
@@ -16807,9 +15301,7 @@
   "type": "Dividend",
   "company": "Royal Dutch",
   "symbol": "R6C.DE",
-  "date": {
-    "$date": "2016-03-29T00:00:00Z"
-  },
+  "date": "2016-03-29",
   "shares": 171,
   "amount": 53.28,
   "grossAmount": 0,
@@ -16829,9 +15321,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2016-03-31T00:00:00Z"
-  },
+  "date": "2016-03-31",
   "shares": 163,
   "amount": 26.36,
   "grossAmount": 0,
@@ -16851,9 +15341,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2016-03-31T00:00:00Z"
-  },
+  "date": "2016-03-31",
   "shares": 48,
   "amount": 6.77,
   "grossAmount": 0,
@@ -16873,9 +15361,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2016-03-29T00:00:00Z"
-  },
+  "date": "2016-03-29",
   "shares": 6570,
   "amount": 694.72,
   "grossAmount": 0,
@@ -16895,9 +15381,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2016-03-31T00:00:00Z"
-  },
+  "date": "2016-03-31",
   "shares": 217.5,
   "amount": 12.61,
   "grossAmount": 0,
@@ -16917,9 +15401,7 @@
   "type": "Dividend",
   "company": "Wal-Mart",
   "symbol": "WMT.F",
-  "date": {
-    "$date": "2016-04-04T00:00:00Z"
-  },
+  "date": "2016-04-04",
   "shares": 40,
   "amount": 12.95,
   "grossAmount": 0,
@@ -16939,9 +15421,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2016-04-01T00:00:00Z"
-  },
+  "date": "2016-04-01",
   "shares": 300,
   "amount": 54.73,
   "grossAmount": 0,
@@ -16961,9 +15441,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2016-04-07T00:00:00Z"
-  },
+  "date": "2016-04-07",
   "shares": 150,
   "amount": 32.02,
   "grossAmount": 0,
@@ -16983,9 +15461,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2016-04-11T00:00:00Z"
-  },
+  "date": "2016-04-11",
   "shares": 41,
   "amount": 26.39,
   "grossAmount": 0,
@@ -17005,9 +15481,7 @@
   "type": "Dividend",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2016-04-13T00:00:00Z"
-  },
+  "date": "2016-04-13",
   "shares": 48,
   "amount": 53.23,
   "grossAmount": 0,
@@ -17027,9 +15501,7 @@
   "type": "Dividend",
   "company": "\"Yamana Gold \"",
   "symbol": "AUY",
-  "date": {
-    "$date": "2016-04-14T00:00:00Z"
-  },
+  "date": "2016-04-14",
   "shares": 480,
   "amount": 1.59,
   "grossAmount": 0,
@@ -17049,9 +15521,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2016-04-15T00:00:00Z"
-  },
+  "date": "2016-04-15",
   "shares": 76,
   "amount": 11.42,
   "grossAmount": 0,
@@ -17071,9 +15541,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2016-04-28T00:00:00Z"
-  },
+  "date": "2016-04-28",
   "shares": 22,
   "amount": 7.29,
   "grossAmount": 0,
@@ -17093,9 +15561,7 @@
   "type": "Dividend",
   "company": "First Industrial Realty Trust",
   "symbol": "FR",
-  "date": {
-    "$date": "2016-04-18T00:00:00Z"
-  },
+  "date": "2016-04-18",
   "shares": 150,
   "amount": 18.55,
   "grossAmount": 0,
@@ -17115,9 +15581,7 @@
   "type": "Dividend",
   "company": "ISHSVI-G.C.BD EO H DIST",
   "symbol": "CRPH.L",
-  "date": {
-    "$date": "2016-04-29T00:00:00Z"
-  },
+  "date": "2016-04-29",
   "shares": 610,
   "amount": 454.69,
   "grossAmount": 0,
@@ -17137,9 +15601,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2016-05-02T00:00:00Z"
-  },
+  "date": "2016-05-02",
   "shares": 25,
   "amount": 9.61,
   "grossAmount": 0,
@@ -17159,9 +15621,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2016-05-03T00:00:00Z"
-  },
+  "date": "2016-05-03",
   "shares": 101,
   "amount": 16.29,
   "grossAmount": 0,
@@ -17181,9 +15641,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2016-05-04T00:00:00Z"
-  },
+  "date": "2016-05-04",
   "shares": 70,
   "amount": 44.43,
   "grossAmount": 0,
@@ -17203,9 +15661,7 @@
   "type": "Dividend",
   "company": "British American Tobacco",
   "symbol": "BATS.L",
-  "date": {
-    "$date": "2016-05-05T00:00:00Z"
-  },
+  "date": "2016-05-05",
   "shares": 40,
   "amount": 38.28,
   "grossAmount": 0,
@@ -17225,9 +15681,7 @@
   "type": "Dividend",
   "company": "GBL",
   "symbol": "GBLB.BR",
-  "date": {
-    "$date": "2016-05-05T00:00:00Z"
-  },
+  "date": "2016-05-05",
   "shares": 37,
   "amount": 65.41,
   "grossAmount": 0,
@@ -17247,9 +15701,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2016-05-09T00:00:00Z"
-  },
+  "date": "2016-05-09",
   "shares": 43,
   "amount": 5.29,
   "grossAmount": 0,
@@ -17269,9 +15721,7 @@
   "type": "Dividend",
   "company": "\"Fresnillo \"",
   "symbol": "FRES.L",
-  "date": {
-    "$date": "2016-05-09T00:00:00Z"
-  },
+  "date": "2016-05-09",
   "shares": 333,
   "amount": 6.99,
   "grossAmount": 0,
@@ -17291,9 +15741,7 @@
   "type": "Dividend",
   "company": "\"Jardine Matheson \"",
   "symbol": "J36.SI",
-  "date": {
-    "$date": "2016-05-11T00:00:00Z"
-  },
+  "date": "2016-05-11",
   "shares": 50,
   "amount": 33.75,
   "grossAmount": 0,
@@ -17313,9 +15761,7 @@
   "type": "Dividend",
   "company": "\"City Developments \"",
   "symbol": "C09.SI",
-  "date": {
-    "$date": "2016-05-20T00:00:00Z"
-  },
+  "date": "2016-05-20",
   "shares": 420,
   "amount": 23.17,
   "grossAmount": 0,
@@ -17335,9 +15781,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2016-05-17T00:00:00Z"
-  },
+  "date": "2016-05-17",
   "shares": 209,
   "amount": 164.53,
   "grossAmount": 0,
@@ -17357,9 +15801,7 @@
   "type": "Dividend",
   "company": "\"Vornado Realty Trust \"",
   "symbol": "VNO",
-  "date": {
-    "$date": "2016-05-20T00:00:00Z"
-  },
+  "date": "2016-05-20",
   "shares": 45,
   "amount": 18.61,
   "grossAmount": 0,
@@ -17379,9 +15821,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2016-05-27T00:00:00Z"
-  },
+  "date": "2016-05-27",
   "shares": 105,
   "amount": 4.85,
   "grossAmount": 0,
@@ -17401,9 +15841,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2016-06-01T00:00:00Z"
-  },
+  "date": "2016-06-01",
   "shares": 92,
   "amount": 21.75,
   "grossAmount": 0,
@@ -17423,9 +15861,7 @@
   "type": "Dividend",
   "company": "Intel",
   "symbol": "INL.F",
-  "date": {
-    "$date": "2016-06-01T00:00:00Z"
-  },
+  "date": "2016-06-01",
   "shares": 100,
   "amount": 17.15,
   "grossAmount": 0,
@@ -17445,9 +15881,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2016-06-01T00:00:00Z"
-  },
+  "date": "2016-06-01",
   "shares": 356,
   "amount": 54.54,
   "grossAmount": 0,
@@ -17467,9 +15901,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2016-06-02T00:00:00Z"
-  },
+  "date": "2016-06-02",
   "shares": 68,
   "amount": 5.81,
   "grossAmount": 0,
@@ -17489,9 +15921,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2016-06-07T00:00:00Z"
-  },
+  "date": "2016-06-07",
   "shares": 35,
   "amount": 18.12,
   "grossAmount": 0,
@@ -17511,9 +15941,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2016-06-15T00:00:00Z"
-  },
+  "date": "2016-06-15",
   "shares": 50,
   "amount": 4.26,
   "grossAmount": 0,
@@ -17533,9 +15961,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2016-06-09T00:00:00Z"
-  },
+  "date": "2016-06-09",
   "shares": 75,
   "amount": 17.5,
   "grossAmount": 0,
@@ -17555,9 +15981,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2016-06-15T00:00:00Z"
-  },
+  "date": "2016-06-15",
   "shares": 280,
   "amount": 3.67,
   "grossAmount": 0,
@@ -17577,9 +16001,7 @@
   "type": "Dividend",
   "company": "\"Agnico-Eagle Mines Ltd. \"",
   "symbol": "AEM",
-  "date": {
-    "$date": "2016-06-15T00:00:00Z"
-  },
+  "date": "2016-06-15",
   "shares": 128,
   "amount": 6.69,
   "grossAmount": 0,
@@ -17599,9 +16021,7 @@
   "type": "Dividend",
   "company": "Great Eagle Holdings",
   "symbol": "0041.HK",
-  "date": {
-    "$date": "2016-06-22T00:00:00Z"
-  },
+  "date": "2016-06-22",
   "shares": 1000,
   "amount": 200.74,
   "grossAmount": 0,
@@ -17621,9 +16041,7 @@
   "type": "Dividend",
   "company": "Deutsche Wohnen",
   "symbol": "DWNI.DE",
-  "date": {
-    "$date": "2016-06-23T00:00:00Z"
-  },
+  "date": "2016-06-23",
   "shares": 110,
   "amount": 52.02,
   "grossAmount": 0,
@@ -17643,9 +16061,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2016-06-23T00:00:00Z"
-  },
+  "date": "2016-06-23",
   "shares": 114,
   "amount": 1.84,
   "grossAmount": 0,
@@ -17665,9 +16081,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2016-06-29T00:00:00Z"
-  },
+  "date": "2016-06-29",
   "shares": 6570,
   "amount": 1281.03,
   "grossAmount": 0,
@@ -17687,9 +16101,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2016-06-29T00:00:00Z"
-  },
+  "date": "2016-06-29",
   "shares": 300,
   "amount": 99.16,
   "grossAmount": 0,
@@ -17709,9 +16121,7 @@
   "type": "Dividend",
   "company": "Ametek",
   "symbol": "AME",
-  "date": {
-    "$date": "2016-06-30T00:00:00Z"
-  },
+  "date": "2016-06-30",
   "shares": 48,
   "amount": 2.85,
   "grossAmount": 0,
@@ -17731,9 +16141,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2016-06-30T00:00:00Z"
-  },
+  "date": "2016-06-30",
   "shares": 163,
   "amount": 26.9,
   "grossAmount": 0,
@@ -17753,9 +16161,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2016-06-30T00:00:00Z"
-  },
+  "date": "2016-06-30",
   "shares": 217.5,
   "amount": 12.58,
   "grossAmount": 0,
@@ -17775,9 +16181,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2016-06-30T00:00:00Z"
-  },
+  "date": "2016-06-30",
   "shares": 48,
   "amount": 6.85,
   "grossAmount": 0,
@@ -17797,9 +16201,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2016-07-11T00:00:00Z"
-  },
+  "date": "2016-07-11",
   "shares": 41,
   "amount": 27.22,
   "grossAmount": 0,
@@ -17819,9 +16221,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2016-07-15T00:00:00Z"
-  },
+  "date": "2016-07-15",
   "shares": 22,
   "amount": 7.71,
   "grossAmount": 0,
@@ -17841,9 +16241,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2016-07-15T00:00:00Z"
-  },
+  "date": "2016-07-15",
   "shares": 76,
   "amount": 11.56,
   "grossAmount": 0,
@@ -17863,9 +16261,7 @@
   "type": "Dividend",
   "company": "First Industrial Realty Trust",
   "symbol": "FR",
-  "date": {
-    "$date": "2016-07-18T00:00:00Z"
-  },
+  "date": "2016-07-18",
   "shares": 150,
   "amount": 19.03,
   "grossAmount": 0,
@@ -17885,9 +16281,7 @@
   "type": "Dividend",
   "company": "\"ISHSIII-C.EO CORP.B.EODIS \"",
   "symbol": "IEAC.AS",
-  "date": {
-    "$date": "2016-07-29T00:00:00Z"
-  },
+  "date": "2016-07-29",
   "shares": 490,
   "amount": 366.67,
   "grossAmount": 0,
@@ -17907,9 +16301,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2016-08-01T00:00:00Z"
-  },
+  "date": "2016-08-01",
   "shares": 25,
   "amount": 9.86,
   "grossAmount": 0,
@@ -17929,9 +16321,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2016-08-09T00:00:00Z"
-  },
+  "date": "2016-08-09",
   "shares": 43,
   "amount": 5.45,
   "grossAmount": 0,
@@ -17951,9 +16341,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2016-08-02T00:00:00Z"
-  },
+  "date": "2016-08-02",
   "shares": 101,
   "amount": 16.67,
   "grossAmount": 0,
@@ -17973,9 +16361,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2016-08-11T00:00:00Z"
-  },
+  "date": "2016-08-11",
   "shares": 70,
   "amount": 26.87,
   "grossAmount": 0,
@@ -17995,9 +16381,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2016-08-26T00:00:00Z"
-  },
+  "date": "2016-08-26",
   "shares": 173,
   "amount": 7.91,
   "grossAmount": 0,
@@ -18017,9 +16401,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2016-09-01T00:00:00Z"
-  },
+  "date": "2016-09-01",
   "shares": 68,
   "amount": 5.85,
   "grossAmount": 0,
@@ -18039,9 +16421,7 @@
   "type": "Dividend",
   "company": "\"Vornado Realty Trust \"",
   "symbol": "VNO",
-  "date": {
-    "$date": "2016-08-19T00:00:00Z"
-  },
+  "date": "2016-08-19",
   "shares": 45,
   "amount": 18.42,
   "grossAmount": 0,
@@ -18061,9 +16441,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2016-09-06T00:00:00Z"
-  },
+  "date": "2016-09-06",
   "shares": 35,
   "amount": 18.46,
   "grossAmount": 0,
@@ -18083,9 +16461,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2016-09-07T00:00:00Z"
-  },
+  "date": "2016-09-07",
   "shares": 92,
   "amount": 21.75,
   "grossAmount": 0,
@@ -18105,9 +16481,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2016-09-08T00:00:00Z"
-  },
+  "date": "2016-09-08",
   "shares": 75,
   "amount": 17.61,
   "grossAmount": 0,
@@ -18127,9 +16501,7 @@
   "type": "Dividend",
   "company": "\"Fresnillo \"",
   "symbol": "FRES.L",
-  "date": {
-    "$date": "2016-09-09T00:00:00Z"
-  },
+  "date": "2016-09-09",
   "shares": 256,
   "amount": 14.51,
   "grossAmount": 0,
@@ -18149,9 +16521,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2016-09-15T00:00:00Z"
-  },
+  "date": "2016-09-15",
   "shares": 50,
   "amount": 4.26,
   "grossAmount": 0,
@@ -18171,9 +16541,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2016-09-22T00:00:00Z"
-  },
+  "date": "2016-09-22",
   "shares": 356,
   "amount": 21.57,
   "grossAmount": 0,
@@ -18193,9 +16561,7 @@
   "type": "Dividend",
   "company": "\"Agnico-Eagle Mines Ltd. \"",
   "symbol": "AEM",
-  "date": {
-    "$date": "2016-09-15T00:00:00Z"
-  },
+  "date": "2016-09-15",
   "shares": 97,
   "amount": 6.38,
   "grossAmount": 0,
@@ -18215,9 +16581,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2016-09-15T00:00:00Z"
-  },
+  "date": "2016-09-15",
   "shares": 280,
   "amount": 3.69,
   "grossAmount": 0,
@@ -18237,9 +16601,7 @@
   "type": "Dividend",
   "company": "British American Tobacco",
   "symbol": "BATS.L",
-  "date": {
-    "$date": "2016-09-28T00:00:00Z"
-  },
+  "date": "2016-09-28",
   "shares": 40,
   "amount": 17.06,
   "grossAmount": 0,
@@ -18259,9 +16621,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2016-09-29T00:00:00Z"
-  },
+  "date": "2016-09-29",
   "shares": 114,
   "amount": 1.87,
   "grossAmount": 0,
@@ -18281,9 +16641,7 @@
   "type": "Dividend",
   "company": "\"Compagnie Financiere Richemont SA \"",
   "symbol": "CFR.SW",
-  "date": {
-    "$date": "2016-09-23T00:00:00Z"
-  },
+  "date": "2016-09-23",
   "shares": 85,
   "amount": 71.26,
   "grossAmount": 0,
@@ -18303,9 +16661,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2016-09-30T00:00:00Z"
-  },
+  "date": "2016-09-30",
   "shares": 6570,
   "amount": 679,
   "grossAmount": 0,
@@ -18325,9 +16681,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2016-09-29T00:00:00Z"
-  },
+  "date": "2016-09-29",
   "shares": 48,
   "amount": 6.97,
   "grossAmount": 0,
@@ -18347,9 +16701,7 @@
   "type": "Dividend",
   "company": "Ametek",
   "symbol": "AME",
-  "date": {
-    "$date": "2016-09-30T00:00:00Z"
-  },
+  "date": "2016-09-30",
   "shares": 48,
   "amount": 2.84,
   "grossAmount": 0,
@@ -18369,9 +16721,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2016-09-30T00:00:00Z"
-  },
+  "date": "2016-09-30",
   "shares": 217.5,
   "amount": 12.46,
   "grossAmount": 0,
@@ -18391,9 +16741,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2016-09-30T00:00:00Z"
-  },
+  "date": "2016-09-30",
   "shares": 163,
   "amount": 26.7,
   "grossAmount": 0,
@@ -18413,9 +16761,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2016-10-05T00:00:00Z"
-  },
+  "date": "2016-10-05",
   "shares": 300,
   "amount": 68.31,
   "grossAmount": 0,
@@ -18435,9 +16781,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2016-10-13T00:00:00Z"
-  },
+  "date": "2016-10-13",
   "shares": 41,
   "amount": 27.8,
   "grossAmount": 0,
@@ -18457,9 +16801,7 @@
   "type": "Dividend",
   "company": "Great Eagle Holdings",
   "symbol": "0041.HK",
-  "date": {
-    "$date": "2016-10-14T00:00:00Z"
-  },
+  "date": "2016-10-14",
   "shares": 1000,
   "amount": 22.59,
   "grossAmount": 0,
@@ -18479,9 +16821,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2016-10-06T00:00:00Z"
-  },
+  "date": "2016-10-06",
   "shares": 239,
   "amount": 69.05,
   "grossAmount": 0,
@@ -18501,9 +16841,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2016-10-14T00:00:00Z"
-  },
+  "date": "2016-10-14",
   "shares": 56,
   "amount": 8.61,
   "grossAmount": 0,
@@ -18523,9 +16861,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2016-10-17T00:00:00Z"
-  },
+  "date": "2016-10-17",
   "shares": 37,
   "amount": 13.64,
   "grossAmount": 0,
@@ -18545,9 +16881,7 @@
   "type": "Dividend",
   "company": "First Industrial Realty Trust",
   "symbol": "FR",
-  "date": {
-    "$date": "2016-10-17T00:00:00Z"
-  },
+  "date": "2016-10-17",
   "shares": 150,
   "amount": 19.09,
   "grossAmount": 0,
@@ -18567,9 +16901,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2016-10-26T00:00:00Z"
-  },
+  "date": "2016-10-26",
   "shares": 97,
   "amount": 9.81,
   "grossAmount": 0,
@@ -18589,9 +16921,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2016-11-01T00:00:00Z"
-  },
+  "date": "2016-11-01",
   "shares": 25,
   "amount": 10.04,
   "grossAmount": 0,
@@ -18611,9 +16941,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2016-11-02T00:00:00Z"
-  },
+  "date": "2016-11-02",
   "shares": 204,
   "amount": 13.49,
   "grossAmount": 0,
@@ -18633,9 +16961,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2016-11-09T00:00:00Z"
-  },
+  "date": "2016-11-09",
   "shares": 43,
   "amount": 5.42,
   "grossAmount": 0,
@@ -18655,9 +16981,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2016-11-28T00:00:00Z"
-  },
+  "date": "2016-11-28",
   "shares": 173,
   "amount": 8.4,
   "grossAmount": 0,
@@ -18677,9 +17001,7 @@
   "type": "Dividend",
   "company": "\"Vornado Realty Trust \"",
   "symbol": "VNO",
-  "date": {
-    "$date": "2016-11-21T00:00:00Z"
-  },
+  "date": "2016-11-21",
   "shares": 45,
   "amount": 19.66,
   "grossAmount": 0,
@@ -18699,9 +17021,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2016-12-01T00:00:00Z"
-  },
+  "date": "2016-12-01",
   "shares": 68,
   "amount": 6.13,
   "grossAmount": 0,
@@ -18721,9 +17041,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2016-12-06T00:00:00Z"
-  },
+  "date": "2016-12-06",
   "shares": 35,
   "amount": 19.15,
   "grossAmount": 0,
@@ -18743,9 +17061,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2016-12-07T00:00:00Z"
-  },
+  "date": "2016-12-07",
   "shares": 92,
   "amount": 21.75,
   "grossAmount": 0,
@@ -18765,9 +17081,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2016-12-08T00:00:00Z"
-  },
+  "date": "2016-12-08",
   "shares": 75,
   "amount": 19.94,
   "grossAmount": 0,
@@ -18787,9 +17101,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2016-12-15T00:00:00Z"
-  },
+  "date": "2016-12-15",
   "shares": 50,
   "amount": 4.58,
   "grossAmount": 0,
@@ -18809,9 +17121,7 @@
   "type": "Dividend",
   "company": "KWS Saat",
   "symbol": "KWS.DE",
-  "date": {
-    "$date": "2016-12-16T00:00:00Z"
-  },
+  "date": "2016-12-16",
   "shares": 7,
   "amount": 15.13,
   "grossAmount": 0,
@@ -18831,9 +17141,7 @@
   "type": "Dividend",
   "company": "\"Agnico-Eagle Mines Ltd. \"",
   "symbol": "AEM",
-  "date": {
-    "$date": "2016-12-15T00:00:00Z"
-  },
+  "date": "2016-12-15",
   "shares": 97,
   "amount": 6.85,
   "grossAmount": 0,
@@ -18853,9 +17161,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2016-12-15T00:00:00Z"
-  },
+  "date": "2016-12-15",
   "shares": 280,
   "amount": 3.99,
   "grossAmount": 0,
@@ -18875,9 +17181,7 @@
   "type": "Dividend",
   "company": "Ametek",
   "symbol": "AME",
-  "date": {
-    "$date": "2016-12-21T00:00:00Z"
-  },
+  "date": "2016-12-21",
   "shares": 84,
   "amount": 5.36,
   "grossAmount": 0,
@@ -18897,9 +17201,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2016-12-22T00:00:00Z"
-  },
+  "date": "2016-12-22",
   "shares": 48,
   "amount": 7.41,
   "grossAmount": 0,
@@ -18919,9 +17221,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2016-12-29T00:00:00Z"
-  },
+  "date": "2016-12-29",
   "shares": 114,
   "amount": 4.02,
   "grossAmount": 0,
@@ -18941,9 +17241,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2016-12-30T00:00:00Z"
-  },
+  "date": "2016-12-30",
   "shares": 6570,
   "amount": 706.02,
   "grossAmount": 0,
@@ -18963,9 +17261,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2016-12-30T00:00:00Z"
-  },
+  "date": "2016-12-30",
   "shares": 300,
   "amount": 57.83,
   "grossAmount": 0,
@@ -18985,9 +17281,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2016-12-30T00:00:00Z"
-  },
+  "date": "2016-12-30",
   "shares": 163,
   "amount": 28.35,
   "grossAmount": 0,
@@ -19007,9 +17301,7 @@
   "type": "Dividend",
   "company": "Philip Morris",
   "symbol": "PM",
-  "date": {
-    "$date": "2017-01-10T00:00:00Z"
-  },
+  "date": "2017-01-10",
   "shares": 41,
   "amount": 28.93,
   "grossAmount": 0,
@@ -19029,9 +17321,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2016-12-31T00:00:00Z"
-  },
+  "date": "2016-12-31",
   "shares": 217.5,
   "amount": 13.25,
   "grossAmount": 0,
@@ -19051,9 +17341,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2017-01-13T00:00:00Z"
-  },
+  "date": "2017-01-13",
   "shares": 37,
   "amount": 14.83,
   "grossAmount": 0,
@@ -19073,9 +17361,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2017-01-26T00:00:00Z"
-  },
+  "date": "2017-01-26",
   "shares": 97,
   "amount": 10,
   "grossAmount": 0,
@@ -19095,9 +17381,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2017-02-09T00:00:00Z"
-  },
+  "date": "2017-02-09",
   "shares": 43,
   "amount": 6.51,
   "grossAmount": 0,
@@ -19117,9 +17401,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2017-02-24T00:00:00Z"
-  },
+  "date": "2017-02-24",
   "shares": 173,
   "amount": 9.63,
   "grossAmount": 0,
@@ -19139,9 +17421,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2017-03-02T00:00:00Z"
-  },
+  "date": "2017-03-02",
   "shares": 68,
   "amount": 6.19,
   "grossAmount": 0,
@@ -19161,9 +17441,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2017-03-09T00:00:00Z"
-  },
+  "date": "2017-03-09",
   "shares": 75,
   "amount": 20.38,
   "grossAmount": 0,
@@ -19183,9 +17461,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2017-03-14T00:00:00Z"
-  },
+  "date": "2017-03-14",
   "shares": 35,
   "amount": 19.37,
   "grossAmount": 0,
@@ -19205,9 +17481,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2017-03-15T00:00:00Z"
-  },
+  "date": "2017-03-15",
   "shares": 92,
   "amount": 21.75,
   "grossAmount": 0,
@@ -19227,9 +17501,7 @@
   "type": "Dividend",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2017-03-20T00:00:00Z"
-  },
+  "date": "2017-03-20",
   "shares": 25,
   "amount": 102.43,
   "grossAmount": 0,
@@ -19249,9 +17521,7 @@
   "type": "Dividend",
   "company": "Ametek",
   "symbol": "AME",
-  "date": {
-    "$date": "2017-03-30T00:00:00Z"
-  },
+  "date": "2017-03-30",
   "shares": 84,
   "amount": 5.21,
   "grossAmount": 0,
@@ -19271,9 +17541,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2017-03-31T00:00:00Z"
-  },
+  "date": "2017-03-31",
   "shares": 288,
   "amount": 18.61,
   "grossAmount": 0,
@@ -19293,9 +17561,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2017-04-06T00:00:00Z"
-  },
+  "date": "2017-04-06",
   "shares": 239,
   "amount": 47.48,
   "grossAmount": 0,
@@ -19315,9 +17581,7 @@
   "type": "Dividend",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2017-04-12T00:00:00Z"
-  },
+  "date": "2017-04-12",
   "shares": 71,
   "amount": 81.94,
   "grossAmount": 0,
@@ -19337,9 +17601,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2017-04-26T00:00:00Z"
-  },
+  "date": "2017-04-26",
   "shares": 97,
   "amount": 12.44,
   "grossAmount": 0,
@@ -19359,9 +17621,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2017-04-28T00:00:00Z"
-  },
+  "date": "2017-04-28",
   "shares": 37,
   "amount": 15.5,
   "grossAmount": 0,
@@ -19381,9 +17641,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2017-05-03T00:00:00Z"
-  },
+  "date": "2017-05-03",
   "shares": 70,
   "amount": 42.38,
   "grossAmount": 0,
@@ -19403,9 +17661,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2017-05-09T00:00:00Z"
-  },
+  "date": "2017-05-09",
   "shares": 43,
   "amount": 6.36,
   "grossAmount": 0,
@@ -19425,9 +17681,7 @@
   "type": "Dividend",
   "company": "Fuchs Petrolub",
   "symbol": "FPE.DE",
-  "date": {
-    "$date": "2017-05-10T00:00:00Z"
-  },
+  "date": "2017-05-10",
   "shares": 61,
   "amount": 38.66,
   "grossAmount": 0,
@@ -19447,9 +17701,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2017-05-10T00:00:00Z"
-  },
+  "date": "2017-05-10",
   "shares": 209,
   "amount": 174.51,
   "grossAmount": 0,
@@ -19469,9 +17721,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2017-05-26T00:00:00Z"
-  },
+  "date": "2017-05-26",
   "shares": 173,
   "amount": 9.09,
   "grossAmount": 0,
@@ -19491,9 +17741,7 @@
   "type": "Dividend",
   "company": "\"CK Hutchison Holdings \"",
   "symbol": "0001.HK",
-  "date": {
-    "$date": "2017-05-31T00:00:00Z"
-  },
+  "date": "2017-05-31",
   "shares": 356,
   "amount": 56.93,
   "grossAmount": 0,
@@ -19513,9 +17761,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2017-06-01T00:00:00Z"
-  },
+  "date": "2017-06-01",
   "shares": 110,
   "amount": 11.27,
   "grossAmount": 0,
@@ -19535,9 +17781,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2017-06-07T00:00:00Z"
-  },
+  "date": "2017-06-07",
   "shares": 92,
   "amount": 24.36,
   "grossAmount": 0,
@@ -19557,9 +17801,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2017-06-08T00:00:00Z"
-  },
+  "date": "2017-06-08",
   "shares": 75,
   "amount": 19.19,
   "grossAmount": 0,
@@ -19579,9 +17821,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2017-06-13T00:00:00Z"
-  },
+  "date": "2017-06-13",
   "shares": 35,
   "amount": 19.29,
   "grossAmount": 0,
@@ -19601,9 +17841,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2017-06-23T00:00:00Z"
-  },
+  "date": "2017-06-23",
   "shares": 288,
   "amount": 1.89,
   "grossAmount": 0,
@@ -19623,9 +17861,7 @@
   "type": "Dividend",
   "company": "Ametek",
   "symbol": "AME",
-  "date": {
-    "$date": "2017-06-30T00:00:00Z"
-  },
+  "date": "2017-06-30",
   "shares": 84,
   "amount": 4.89,
   "grossAmount": 0,
@@ -19645,9 +17881,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2017-06-30T00:00:00Z"
-  },
+  "date": "2017-06-30",
   "shares": 288,
   "amount": 17.72,
   "grossAmount": 0,
@@ -19667,9 +17901,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2017-07-14T00:00:00Z"
-  },
+  "date": "2017-07-14",
   "shares": 37,
   "amount": 15.27,
   "grossAmount": 0,
@@ -19689,9 +17921,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2017-08-02T00:00:00Z"
-  },
+  "date": "2017-08-02",
   "shares": 97,
   "amount": 13.18,
   "grossAmount": 0,
@@ -19711,9 +17941,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2017-08-10T00:00:00Z"
-  },
+  "date": "2017-08-10",
   "shares": 70,
   "amount": 31.43,
   "grossAmount": 0,
@@ -19733,9 +17961,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2017-08-09T00:00:00Z"
-  },
+  "date": "2017-08-09",
   "shares": 43,
   "amount": 6.82,
   "grossAmount": 0,
@@ -19755,9 +17981,7 @@
   "type": "Dividend",
   "company": "\"Vornado Realty Trust \"",
   "symbol": "VNO",
-  "date": {
-    "$date": "2017-08-18T00:00:00Z"
-  },
+  "date": "2017-08-18",
   "shares": 45,
   "amount": 17.03,
   "grossAmount": 0,
@@ -19777,9 +18001,7 @@
   "type": "Dividend",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2017-08-22T00:00:00Z"
-  },
+  "date": "2017-08-22",
   "shares": 51,
   "amount": 12.69,
   "grossAmount": 0,
@@ -19799,9 +18021,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2017-08-25T00:00:00Z"
-  },
+  "date": "2017-08-25",
   "shares": 173,
   "amount": 8.62,
   "grossAmount": 0,
@@ -19821,9 +18041,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2017-08-31T00:00:00Z"
-  },
+  "date": "2017-08-31",
   "shares": 110,
   "amount": 10.64,
   "grossAmount": 0,
@@ -19843,9 +18061,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2017-09-06T00:00:00Z"
-  },
+  "date": "2017-09-06",
   "shares": 92,
   "amount": 24.36,
   "grossAmount": 0,
@@ -19865,9 +18081,7 @@
   "type": "Dividend",
   "company": "\"Fresnillo \"",
   "symbol": "FRES.L",
-  "date": {
-    "$date": "2017-09-08T00:00:00Z"
-  },
+  "date": "2017-09-08",
   "shares": 188,
   "amount": 12.13,
   "grossAmount": 0,
@@ -19887,9 +18101,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2017-09-15T00:00:00Z"
-  },
+  "date": "2017-09-15",
   "shares": 50,
   "amount": 4.33,
   "grossAmount": 0,
@@ -19909,9 +18121,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2017-09-15T00:00:00Z"
-  },
+  "date": "2017-09-15",
   "shares": 280,
   "amount": 5.17,
   "grossAmount": 0,
@@ -19931,9 +18141,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2017-09-28T00:00:00Z"
-  },
+  "date": "2017-09-28",
   "shares": 114,
   "amount": 5.35,
   "grossAmount": 0,
@@ -19953,9 +18161,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2017-09-14T00:00:00Z"
-  },
+  "date": "2017-09-14",
   "shares": 75,
   "amount": 18.1,
   "grossAmount": 0,
@@ -19975,9 +18181,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2017-09-28T00:00:00Z"
-  },
+  "date": "2017-09-28",
   "shares": 48,
   "amount": 6.75,
   "grossAmount": 0,
@@ -19997,9 +18201,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2017-09-29T00:00:00Z"
-  },
+  "date": "2017-09-29",
   "shares": 163,
   "amount": 25.4,
   "grossAmount": 0,
@@ -20019,9 +18221,7 @@
   "type": "Dividend",
   "company": "\"ISHS-MSCI WORLD DL D \"",
   "symbol": "IWRD.AS",
-  "date": {
-    "$date": "2017-09-29T00:00:00Z"
-  },
+  "date": "2017-09-29",
   "shares": 5570,
   "amount": 593.05,
   "grossAmount": 0,
@@ -20041,9 +18241,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2017-09-12T00:00:00Z"
-  },
+  "date": "2017-09-12",
   "shares": 35,
   "amount": 18.04,
   "grossAmount": 0,
@@ -20063,9 +18261,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2017-09-29T00:00:00Z"
-  },
+  "date": "2017-09-29",
   "shares": 288,
   "amount": 16.41,
   "grossAmount": 0,
@@ -20085,9 +18281,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2017-10-04T00:00:00Z"
-  },
+  "date": "2017-10-04",
   "shares": 300,
   "amount": 77.7,
   "grossAmount": 0,
@@ -20107,9 +18301,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2017-10-05T00:00:00Z"
-  },
+  "date": "2017-10-05",
   "shares": 239,
   "amount": 73.82,
   "grossAmount": 0,
@@ -20129,9 +18321,7 @@
   "type": "Dividend",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2017-10-13T00:00:00Z"
-  },
+  "date": "2017-10-13",
   "shares": 36,
   "amount": 6.79,
   "grossAmount": 0,
@@ -20151,9 +18341,7 @@
   "type": "Dividend",
   "company": "First Industrial Realty Trust",
   "symbol": "FR",
-  "date": {
-    "$date": "2017-10-16T00:00:00Z"
-  },
+  "date": "2017-10-16",
   "shares": 150,
   "amount": 19.68,
   "grossAmount": 0,
@@ -20173,9 +18361,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2017-10-17T00:00:00Z"
-  },
+  "date": "2017-10-17",
   "shares": 37,
   "amount": 15.3,
   "grossAmount": 0,
@@ -20195,9 +18381,7 @@
   "type": "Dividend",
   "company": "Great Eagle Holdings",
   "symbol": "0041.HK",
-  "date": {
-    "$date": "2017-10-18T00:00:00Z"
-  },
+  "date": "2017-10-18",
   "shares": 1000,
   "amount": 62.23,
   "grossAmount": 0,
@@ -20217,9 +18401,7 @@
   "type": "Dividend",
   "company": "\"Royal Gold \"",
   "symbol": "RGLD",
-  "date": {
-    "$date": "2017-10-20T00:00:00Z"
-  },
+  "date": "2017-10-20",
   "shares": 56,
   "amount": 8.39,
   "grossAmount": 0,
@@ -20239,9 +18421,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2017-10-25T00:00:00Z"
-  },
+  "date": "2017-10-25",
   "shares": 97,
   "amount": 11.53,
   "grossAmount": 0,
@@ -20261,9 +18441,7 @@
   "type": "Dividend",
   "company": "\"Deere \"",
   "symbol": "DE",
-  "date": {
-    "$date": "2017-11-01T00:00:00Z"
-  },
+  "date": "2017-11-01",
   "shares": 25,
   "amount": 9.5,
   "grossAmount": 0,
@@ -20283,9 +18461,7 @@
   "type": "Dividend",
   "company": "Nutrien",
   "symbol": "NTR",
-  "date": {
-    "$date": "2017-11-01T00:00:00Z"
-  },
+  "date": "2017-11-01",
   "shares": 204,
   "amount": 12.88,
   "grossAmount": 0,
@@ -20305,9 +18481,7 @@
   "type": "Dividend",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2017-11-15T00:00:00Z"
-  },
+  "date": "2017-11-15",
   "shares": 32,
   "amount": 18.64,
   "grossAmount": 0,
@@ -20327,9 +18501,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2017-11-09T00:00:00Z"
-  },
+  "date": "2017-11-09",
   "shares": 43,
   "amount": 6.01,
   "grossAmount": 0,
@@ -20349,9 +18521,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2017-11-30T00:00:00Z"
-  },
+  "date": "2017-11-30",
   "shares": 160,
   "amount": 15.54,
   "grossAmount": 0,
@@ -20371,9 +18541,7 @@
   "type": "Dividend",
   "company": "\"Vornado Realty Trust \"",
   "symbol": "VNO",
-  "date": {
-    "$date": "2017-11-20T00:00:00Z"
-  },
+  "date": "2017-11-20",
   "shares": 45,
   "amount": 16.89,
   "grossAmount": 0,
@@ -20393,9 +18561,7 @@
   "type": "Dividend",
   "company": "COLOPLAST NAM. B DK 1",
   "symbol": "COLO-B.CO",
-  "date": {
-    "$date": "2017-12-12T00:00:00Z"
-  },
+  "date": "2017-12-12",
   "shares": 30,
   "amount": 26.09,
   "grossAmount": 0,
@@ -20415,9 +18581,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2017-11-24T00:00:00Z"
-  },
+  "date": "2017-11-24",
   "shares": 173,
   "amount": 8.59,
   "grossAmount": 0,
@@ -20437,9 +18601,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2017-12-12T00:00:00Z"
-  },
+  "date": "2017-12-12",
   "shares": 35,
   "amount": 18.37,
   "grossAmount": 0,
@@ -20459,9 +18621,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2017-12-13T00:00:00Z"
-  },
+  "date": "2017-12-13",
   "shares": 92,
   "amount": 24.36,
   "grossAmount": 0,
@@ -20481,9 +18641,7 @@
   "type": "Dividend",
   "company": "KWS Saat",
   "symbol": "KWS.DE",
-  "date": {
-    "$date": "2017-12-15T00:00:00Z"
-  },
+  "date": "2017-12-15",
   "shares": 7,
   "amount": 16.13,
   "grossAmount": 0,
@@ -20503,9 +18661,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2017-12-14T00:00:00Z"
-  },
+  "date": "2017-12-14",
   "shares": 75,
   "amount": 19.6,
   "grossAmount": 0,
@@ -20525,9 +18681,7 @@
   "type": "Dividend",
   "company": "\"AGCO \"",
   "symbol": "AGCO",
-  "date": {
-    "$date": "2017-12-15T00:00:00Z"
-  },
+  "date": "2017-12-15",
   "shares": 50,
   "amount": 4.37,
   "grossAmount": 0,
@@ -20547,9 +18701,7 @@
   "type": "Dividend",
   "company": "Barrick Gold Corp.",
   "symbol": "Gold",
-  "date": {
-    "$date": "2017-12-15T00:00:00Z"
-  },
+  "date": "2017-12-15",
   "shares": 280,
   "amount": 5.26,
   "grossAmount": 0,
@@ -20569,9 +18721,7 @@
   "type": "Dividend",
   "company": "VANG.FTSE A.-WO.U.ETF DLD",
   "symbol": "VWRL.AS",
-  "date": {
-    "$date": "2017-12-21T00:00:00Z"
-  },
+  "date": "2017-12-21",
   "shares": 300,
   "amount": 62.21,
   "grossAmount": 0,
@@ -20591,9 +18741,7 @@
   "type": "Dividend",
   "company": "\"Franco-Nevada \"",
   "symbol": "FNV",
-  "date": {
-    "$date": "2017-12-21T00:00:00Z"
-  },
+  "date": "2017-12-21",
   "shares": 48,
   "amount": 6.93,
   "grossAmount": 0,
@@ -20613,9 +18761,7 @@
   "type": "Dividend",
   "company": "\"Newmont Goldcorp Corp. \"",
   "symbol": "NEM",
-  "date": {
-    "$date": "2017-12-28T00:00:00Z"
-  },
+  "date": "2017-12-28",
   "shares": 114,
   "amount": 5.28,
   "grossAmount": 0,
@@ -20635,9 +18781,7 @@
   "type": "Dividend",
   "company": "\"Rayonier \"",
   "symbol": "RYN",
-  "date": {
-    "$date": "2017-12-29T00:00:00Z"
-  },
+  "date": "2017-12-29",
   "shares": 163,
   "amount": 25.02,
   "grossAmount": 0,
@@ -20657,9 +18801,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2017-12-29T00:00:00Z"
-  },
+  "date": "2017-12-29",
   "shares": 288,
   "amount": 16.79,
   "grossAmount": 0,
@@ -20679,9 +18821,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2018-01-24T00:00:00Z"
-  },
+  "date": "2018-01-24",
   "shares": 97,
   "amount": 10.98,
   "grossAmount": 0,
@@ -20701,9 +18841,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2018-01-16T00:00:00Z"
-  },
+  "date": "2018-01-16",
   "shares": 37,
   "amount": 15.59,
   "grossAmount": 0,
@@ -20723,9 +18861,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2018-02-09T00:00:00Z"
-  },
+  "date": "2018-02-09",
   "shares": 43,
   "amount": 6.46,
   "grossAmount": 0,
@@ -20745,9 +18881,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2018-02-23T00:00:00Z"
-  },
+  "date": "2018-02-23",
   "shares": 173,
   "amount": 10.38,
   "grossAmount": 0,
@@ -20767,9 +18901,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2018-03-08T00:00:00Z"
-  },
+  "date": "2018-03-08",
   "shares": 75,
   "amount": 18.67,
   "grossAmount": 0,
@@ -20789,9 +18921,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2018-03-08T00:00:00Z"
-  },
+  "date": "2018-03-08",
   "shares": 160,
   "amount": 14.82,
   "grossAmount": 0,
@@ -20811,9 +18941,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2018-03-13T00:00:00Z"
-  },
+  "date": "2018-03-13",
   "shares": 35,
   "amount": 17.55,
   "grossAmount": 0,
@@ -20833,9 +18961,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2018-03-21T00:00:00Z"
-  },
+  "date": "2018-03-21",
   "shares": 92,
   "amount": 24.36,
   "grossAmount": 0,
@@ -20855,9 +18981,7 @@
   "type": "Dividend",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2018-03-27T00:00:00Z"
-  },
+  "date": "2018-03-27",
   "shares": 89,
   "amount": 35.73,
   "grossAmount": 0,
@@ -20877,9 +19001,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2018-03-29T00:00:00Z"
-  },
+  "date": "2018-03-29",
   "shares": 288,
   "amount": 17.44,
   "grossAmount": 0,
@@ -20899,9 +19021,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2018-04-06T00:00:00Z"
-  },
+  "date": "2018-04-06",
   "shares": 239,
   "amount": 49.08,
   "grossAmount": 0,
@@ -20921,9 +19041,7 @@
   "type": "Dividend",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2018-04-18T00:00:00Z"
-  },
+  "date": "2018-04-18",
   "shares": 94,
   "amount": 98.95,
   "grossAmount": 0,
@@ -20943,9 +19061,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2018-04-27T00:00:00Z"
-  },
+  "date": "2018-04-27",
   "shares": 50,
   "amount": 22.83,
   "grossAmount": 0,
@@ -20965,9 +19081,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2018-05-01T00:00:00Z"
-  },
+  "date": "2018-05-01",
   "shares": 139,
   "amount": 16.2,
   "grossAmount": 0,
@@ -20987,9 +19101,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2018-05-02T00:00:00Z"
-  },
+  "date": "2018-05-02",
   "shares": 70,
   "amount": 48.06,
   "grossAmount": 0,
@@ -21009,9 +19121,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2018-05-09T00:00:00Z"
-  },
+  "date": "2018-05-09",
   "shares": 43,
   "amount": 6.71,
   "grossAmount": 0,
@@ -21031,9 +19141,7 @@
   "type": "Dividend",
   "company": "COLOPLAST NAM. B DK 1",
   "symbol": "COLO-B.CO",
-  "date": {
-    "$date": "2018-05-09T00:00:00Z"
-  },
+  "date": "2018-05-09",
   "shares": 53,
   "amount": 21.93,
   "grossAmount": 0,
@@ -21053,9 +19161,7 @@
   "type": "Dividend",
   "company": "Fuchs Petrolub",
   "symbol": "FPE.DE",
-  "date": {
-    "$date": "2018-05-11T00:00:00Z"
-  },
+  "date": "2018-05-11",
   "shares": 61,
   "amount": 39.55,
   "grossAmount": 0,
@@ -21075,9 +19181,7 @@
   "type": "Dividend",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2018-05-15T00:00:00Z"
-  },
+  "date": "2018-05-15",
   "shares": 32,
   "amount": 18.52,
   "grossAmount": 0,
@@ -21097,9 +19201,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2018-05-16T00:00:00Z"
-  },
+  "date": "2018-05-16",
   "shares": 209,
   "amount": 119.68,
   "grossAmount": 0,
@@ -21119,9 +19221,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2018-05-25T00:00:00Z"
-  },
+  "date": "2018-05-25",
   "shares": 173,
   "amount": 11,
   "grossAmount": 0,
@@ -21141,9 +19241,7 @@
   "type": "Dividend",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2018-06-06T00:00:00Z"
-  },
+  "date": "2018-06-06",
   "shares": 61,
   "amount": 23.99,
   "grossAmount": 0,
@@ -21163,9 +19261,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2018-06-06T00:00:00Z"
-  },
+  "date": "2018-06-06",
   "shares": 92,
   "amount": 26.29,
   "grossAmount": 0,
@@ -21185,9 +19281,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2018-06-07T00:00:00Z"
-  },
+  "date": "2018-06-07",
   "shares": 160,
   "amount": 19.52,
   "grossAmount": 0,
@@ -21207,9 +19301,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2018-06-12T00:00:00Z"
-  },
+  "date": "2018-06-12",
   "shares": 35,
   "amount": 19.61,
   "grossAmount": 0,
@@ -21229,9 +19321,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2018-06-14T00:00:00Z"
-  },
+  "date": "2018-06-14",
   "shares": 75,
   "amount": 19.61,
   "grossAmount": 0,
@@ -21251,9 +19341,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2018-06-29T00:00:00Z"
-  },
+  "date": "2018-06-29",
   "shares": 288,
   "amount": 18.22,
   "grossAmount": 0,
@@ -21273,9 +19361,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2018-07-13T00:00:00Z"
-  },
+  "date": "2018-07-13",
   "shares": 50,
   "amount": 24.26,
   "grossAmount": 0,
@@ -21295,9 +19381,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2018-07-31T00:00:00Z"
-  },
+  "date": "2018-07-31",
   "shares": 139,
   "amount": 19.27,
   "grossAmount": 0,
@@ -21317,9 +19401,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2018-08-09T00:00:00Z"
-  },
+  "date": "2018-08-09",
   "shares": 70,
   "amount": 35.1,
   "grossAmount": 0,
@@ -21339,9 +19421,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2018-08-09T00:00:00Z"
-  },
+  "date": "2018-08-09",
   "shares": 43,
   "amount": 8,
   "grossAmount": 0,
@@ -21361,9 +19441,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2018-08-24T00:00:00Z"
-  },
+  "date": "2018-08-24",
   "shares": 173,
   "amount": 14.25,
   "grossAmount": 0,
@@ -21383,9 +19461,7 @@
   "type": "Dividend",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2018-08-21T00:00:00Z"
-  },
+  "date": "2018-08-21",
   "shares": 89,
   "amount": 22.07,
   "grossAmount": 0,
@@ -21405,9 +19481,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2018-09-05T00:00:00Z"
-  },
+  "date": "2018-09-05",
   "shares": 92,
   "amount": 26.29,
   "grossAmount": 0,
@@ -21427,9 +19501,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2018-09-06T00:00:00Z"
-  },
+  "date": "2018-09-06",
   "shares": 160,
   "amount": 19.78,
   "grossAmount": 0,
@@ -21449,9 +19521,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2018-09-11T00:00:00Z"
-  },
+  "date": "2018-09-11",
   "shares": 35,
   "amount": 19.96,
   "grossAmount": 0,
@@ -21471,9 +19541,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2018-09-13T00:00:00Z"
-  },
+  "date": "2018-09-13",
   "shares": 75,
   "amount": 19.92,
   "grossAmount": 0,
@@ -21493,9 +19561,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2018-09-28T00:00:00Z"
-  },
+  "date": "2018-09-28",
   "shares": 288,
   "amount": 18.58,
   "grossAmount": 0,
@@ -21515,9 +19581,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2018-10-04T00:00:00Z"
-  },
+  "date": "2018-10-04",
   "shares": 239,
   "amount": 78.62,
   "grossAmount": 0,
@@ -21537,9 +19601,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2018-10-17T00:00:00Z"
-  },
+  "date": "2018-10-17",
   "shares": 50,
   "amount": 25.23,
   "grossAmount": 0,
@@ -21559,9 +19621,7 @@
   "type": "Dividend",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2018-10-19T00:00:00Z"
-  },
+  "date": "2018-10-19",
   "shares": 61,
   "amount": 15.92,
   "grossAmount": 0,
@@ -21581,9 +19641,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2018-10-30T00:00:00Z"
-  },
+  "date": "2018-10-30",
   "shares": 139,
   "amount": 17.12,
   "grossAmount": 0,
@@ -21603,9 +19661,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2018-11-09T00:00:00Z"
-  },
+  "date": "2018-11-09",
   "shares": 43,
   "amount": 7.04,
   "grossAmount": 0,
@@ -21625,9 +19681,7 @@
   "type": "Dividend",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2018-11-15T00:00:00Z"
-  },
+  "date": "2018-11-15",
   "shares": 32,
   "amount": 21.35,
   "grossAmount": 0,
@@ -21647,9 +19701,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2018-11-23T00:00:00Z"
-  },
+  "date": "2018-11-23",
   "shares": 173,
   "amount": 14.58,
   "grossAmount": 0,
@@ -21669,9 +19721,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2018-11-15T00:00:00Z"
-  },
+  "date": "2018-11-15",
   "shares": 209,
   "amount": 59.91,
   "grossAmount": 0,
@@ -21691,9 +19741,7 @@
   "type": "Dividend",
   "company": "Fanuc",
   "symbol": "6954.T",
-  "date": {
-    "$date": "2018-12-03T00:00:00Z"
-  },
+  "date": "2018-12-03",
   "shares": 29,
   "amount": 61.32,
   "grossAmount": 0,
@@ -21713,9 +19761,7 @@
   "type": "Dividend",
   "company": "\"TJX Companies \"",
   "symbol": "TJX",
-  "date": {
-    "$date": "2018-12-06T00:00:00Z"
-  },
+  "date": "2018-12-06",
   "shares": 160,
   "amount": 20.19,
   "grossAmount": 0,
@@ -21735,9 +19781,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2018-12-05T00:00:00Z"
-  },
+  "date": "2018-12-05",
   "shares": 92,
   "amount": 26.29,
   "grossAmount": 0,
@@ -21757,9 +19801,7 @@
   "type": "Dividend",
   "company": "COLOPLAST NAM. B DK 1",
   "symbol": "COLO-B.CO",
-  "date": {
-    "$date": "2018-12-10T00:00:00Z"
-  },
+  "date": "2018-12-10",
   "shares": 53,
   "amount": 48.17,
   "grossAmount": 0,
@@ -21779,9 +19821,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2018-12-11T00:00:00Z"
-  },
+  "date": "2018-12-11",
   "shares": 35,
   "amount": 20.37,
   "grossAmount": 0,
@@ -21801,9 +19841,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2018-12-13T00:00:00Z"
-  },
+  "date": "2018-12-13",
   "shares": 75,
   "amount": 22.39,
   "grossAmount": 0,
@@ -21823,9 +19861,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2018-12-31T00:00:00Z"
-  },
+  "date": "2018-12-31",
   "shares": 288,
   "amount": 18.22,
   "grossAmount": 0,
@@ -21845,9 +19881,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2019-01-14T00:00:00Z"
-  },
+  "date": "2019-01-14",
   "shares": 50,
   "amount": 26.97,
   "grossAmount": 0,
@@ -21867,9 +19901,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2019-01-30T00:00:00Z"
-  },
+  "date": "2019-01-30",
   "shares": 139,
   "amount": 16.95,
   "grossAmount": 0,
@@ -21889,9 +19921,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2019-02-08T00:00:00Z"
-  },
+  "date": "2019-02-08",
   "shares": 43,
   "amount": 9.3,
   "grossAmount": 0,
@@ -21911,9 +19941,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2019-02-28T00:00:00Z"
-  },
+  "date": "2019-02-28",
   "shares": 173,
   "amount": 18.95,
   "grossAmount": 0,
@@ -21933,9 +19961,7 @@
   "type": "Dividend",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2019-03-11T00:00:00Z"
-  },
+  "date": "2019-03-11",
   "shares": 15,
   "amount": 74.37,
   "grossAmount": 0,
@@ -21955,9 +19981,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2019-03-12T00:00:00Z"
-  },
+  "date": "2019-03-12",
   "shares": 35,
   "amount": 20.55,
   "grossAmount": 0,
@@ -21977,9 +20001,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2019-03-14T00:00:00Z"
-  },
+  "date": "2019-03-14",
   "shares": 75,
   "amount": 25.8,
   "grossAmount": 0,
@@ -21999,9 +20021,7 @@
   "type": "Dividend",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2019-03-19T00:00:00Z"
-  },
+  "date": "2019-03-19",
   "shares": 20,
   "amount": 13.38,
   "grossAmount": 0,
@@ -22021,9 +20041,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2019-03-20T00:00:00Z"
-  },
+  "date": "2019-03-20",
   "shares": 135,
   "amount": 44.43,
   "grossAmount": 0,
@@ -22043,9 +20061,7 @@
   "type": "Dividend",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2019-03-26T00:00:00Z"
-  },
+  "date": "2019-03-26",
   "shares": 129,
   "amount": 64.79,
   "grossAmount": 0,
@@ -22065,9 +20081,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2019-03-29T00:00:00Z"
-  },
+  "date": "2019-03-29",
   "shares": 288,
   "amount": 20.34,
   "grossAmount": 0,
@@ -22087,9 +20101,7 @@
   "type": "Dividend",
   "company": "NIKE INC. B",
   "symbol": "NKE",
-  "date": {
-    "$date": "2019-04-01T00:00:00Z"
-  },
+  "date": "2019-04-01",
   "shares": 34,
   "amount": 5.64,
   "grossAmount": 0,
@@ -22109,9 +20121,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2019-04-11T00:00:00Z"
-  },
+  "date": "2019-04-11",
   "shares": 239,
   "amount": 71.89,
   "grossAmount": 0,
@@ -22131,9 +20141,7 @@
   "type": "Dividend",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2019-04-17T00:00:00Z"
-  },
+  "date": "2019-04-17",
   "shares": 94,
   "amount": 108.21,
   "grossAmount": 0,
@@ -22153,9 +20161,7 @@
   "type": "Dividend",
   "company": "ECOLAB INC. DL 1",
   "symbol": "ECL",
-  "date": {
-    "$date": "2019-04-15T00:00:00Z"
-  },
+  "date": "2019-04-15",
   "shares": 18,
   "amount": 5.39,
   "grossAmount": 0,
@@ -22175,9 +20181,7 @@
   "type": "Dividend",
   "company": "INTUIT INC. DL-,01",
   "symbol": "INTU",
-  "date": {
-    "$date": "2019-04-18T00:00:00Z"
-  },
+  "date": "2019-04-18",
   "shares": 13,
   "amount": 4.03,
   "grossAmount": 0,
@@ -22197,9 +20201,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2019-04-25T00:00:00Z"
-  },
+  "date": "2019-04-25",
   "shares": 139,
   "amount": 22.01,
   "grossAmount": 0,
@@ -22219,9 +20221,7 @@
   "type": "Dividend",
   "company": "LVMH EO 0,3",
   "symbol": "MC.PA",
-  "date": {
-    "$date": "2019-04-29T00:00:00Z"
-  },
+  "date": "2019-04-29",
   "shares": 10,
   "amount": 22.55,
   "grossAmount": 0,
@@ -22241,9 +20241,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2019-04-26T00:00:00Z"
-  },
+  "date": "2019-04-26",
   "shares": 50,
   "amount": 29.54,
   "grossAmount": 0,
@@ -22263,9 +20261,7 @@
   "type": "Dividend",
   "company": "OREAL (L') INH. EO 0,2",
   "symbol": "OR.PA",
-  "date": {
-    "$date": "2019-04-30T00:00:00Z"
-  },
+  "date": "2019-04-30",
   "shares": 22,
   "amount": 47.73,
   "grossAmount": 0,
@@ -22285,9 +20281,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2019-05-08T00:00:00Z"
-  },
+  "date": "2019-05-08",
   "shares": 70,
   "amount": 52.18,
   "grossAmount": 0,
@@ -22307,9 +20301,7 @@
   "type": "Dividend",
   "company": "COLOPLAST NAM. B DK 1",
   "symbol": "COLO-B.CO",
-  "date": {
-    "$date": "2019-05-08T00:00:00Z"
-  },
+  "date": "2019-05-08",
   "shares": 53,
   "amount": 21.88,
   "grossAmount": 0,
@@ -22329,9 +20321,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2019-05-09T00:00:00Z"
-  },
+  "date": "2019-05-09",
   "shares": 43,
   "amount": 9.3,
   "grossAmount": 0,
@@ -22351,9 +20341,7 @@
   "type": "Dividend",
   "company": "Fuchs Petrolub",
   "symbol": "FPE.DE",
-  "date": {
-    "$date": "2019-05-10T00:00:00Z"
-  },
+  "date": "2019-05-10",
   "shares": 99,
   "amount": 67.02,
   "grossAmount": 0,
@@ -22373,9 +20361,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2019-05-15T00:00:00Z"
-  },
+  "date": "2019-05-15",
   "shares": 209,
   "amount": 102.53,
   "grossAmount": 0,
@@ -22395,9 +20381,7 @@
   "type": "Dividend",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2019-05-15T00:00:00Z"
-  },
+  "date": "2019-05-15",
   "shares": 32,
   "amount": 21.74,
   "grossAmount": 0,
@@ -22417,9 +20401,7 @@
   "type": "Dividend",
   "company": "ESSILORLUXO. INH. EO -,18",
   "symbol": "EL.PA",
-  "date": {
-    "$date": "2019-05-23T00:00:00Z"
-  },
+  "date": "2019-05-23",
   "shares": 45,
   "amount": 51.99,
   "grossAmount": 0,
@@ -22439,9 +20421,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2019-05-29T00:00:00Z"
-  },
+  "date": "2019-05-29",
   "shares": 173,
   "amount": 19.44,
   "grossAmount": 0,
@@ -22461,9 +20441,7 @@
   "type": "Dividend",
   "company": "DASSAULT SYS SA INH.EO0,5",
   "symbol": "DSY.PA",
-  "date": {
-    "$date": "2019-05-31T00:00:00Z"
-  },
+  "date": "2019-05-31",
   "shares": 20,
   "amount": 7.32,
   "grossAmount": 0,
@@ -22483,9 +20461,7 @@
   "type": "Dividend",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2019-06-04T00:00:00Z"
-  },
+  "date": "2019-06-04",
   "shares": 90,
   "amount": 49.16,
   "grossAmount": 0,
@@ -22505,9 +20481,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2019-06-05T00:00:00Z"
-  },
+  "date": "2019-06-05",
   "shares": 135,
   "amount": 40.9,
   "grossAmount": 0,
@@ -22527,9 +20501,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2019-06-11T00:00:00Z"
-  },
+  "date": "2019-06-11",
   "shares": 35,
   "amount": 21.69,
   "grossAmount": 0,
@@ -22549,9 +20521,7 @@
   "type": "Dividend",
   "company": "AIA GROUP LTD",
   "symbol": "1299.HK",
-  "date": {
-    "$date": "2019-06-06T00:00:00Z"
-  },
+  "date": "2019-06-06",
   "shares": 300,
   "amount": 23.01,
   "grossAmount": 0,
@@ -22571,9 +20541,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2019-06-13T00:00:00Z"
-  },
+  "date": "2019-06-13",
   "shares": 75,
   "amount": 22.56,
   "grossAmount": 0,
@@ -22593,9 +20561,7 @@
   "type": "Dividend",
   "company": "KEYENCE CORP.",
   "symbol": "6861.T",
-  "date": {
-    "$date": "2019-06-17T00:00:00Z"
-  },
+  "date": "2019-06-17",
   "shares": 18,
   "amount": 2.99,
   "grossAmount": 0,
@@ -22615,9 +20581,7 @@
   "type": "Dividend",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2019-06-25T00:00:00Z"
-  },
+  "date": "2019-06-25",
   "shares": 15,
   "amount": 7.31,
   "grossAmount": 0,
@@ -22637,9 +20601,7 @@
   "type": "Dividend",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2019-06-25T00:00:00Z"
-  },
+  "date": "2019-06-25",
   "shares": 30,
   "amount": 20.96,
   "grossAmount": 0,
@@ -22659,9 +20621,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2019-06-28T00:00:00Z"
-  },
+  "date": "2019-06-28",
   "shares": 288,
   "amount": 17.56,
   "grossAmount": 0,
@@ -22681,9 +20641,7 @@
   "type": "Dividend",
   "company": "Fanuc",
   "symbol": "6954.T",
-  "date": {
-    "$date": "2019-06-28T00:00:00Z"
-  },
+  "date": "2019-06-28",
   "shares": 29,
   "amount": 70.16,
   "grossAmount": 0,
@@ -22703,9 +20661,7 @@
   "type": "Dividend",
   "company": "NIKE INC. B",
   "symbol": "NKE",
-  "date": {
-    "$date": "2019-07-01T00:00:00Z"
-  },
+  "date": "2019-07-01",
   "shares": 60,
   "amount": 8.6,
   "grossAmount": 0,
@@ -22725,9 +20681,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2019-07-12T00:00:00Z"
-  },
+  "date": "2019-07-12",
   "shares": 50,
   "amount": 30.02,
   "grossAmount": 0,
@@ -22747,9 +20701,7 @@
   "type": "Dividend",
   "company": "ECOLAB INC. DL 1",
   "symbol": "ECL",
-  "date": {
-    "$date": "2019-07-15T00:00:00Z"
-  },
+  "date": "2019-07-15",
   "shares": 18,
   "amount": 5.45,
   "grossAmount": 0,
@@ -22769,9 +20721,7 @@
   "type": "Dividend",
   "company": "INTUIT INC. DL-,01",
   "symbol": "INTU",
-  "date": {
-    "$date": "2019-07-18T00:00:00Z"
-  },
+  "date": "2019-07-18",
   "shares": 22,
   "amount": 6.8,
   "grossAmount": 0,
@@ -22791,9 +20741,7 @@
   "type": "Dividend",
   "company": "HDFC BANK LTD ADR/3 IR 10",
   "symbol": "HDB",
-  "date": {
-    "$date": "2019-07-25T00:00:00Z"
-  },
+  "date": "2019-07-25",
   "shares": 56,
   "amount": 11.16,
   "grossAmount": 0,
@@ -22813,9 +20761,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2019-07-31T00:00:00Z"
-  },
+  "date": "2019-07-31",
   "shares": 139,
   "amount": 22.16,
   "grossAmount": 0,
@@ -22835,9 +20781,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2019-08-08T00:00:00Z"
-  },
+  "date": "2019-08-08",
   "shares": 70,
   "amount": 33.07,
   "grossAmount": 0,
@@ -22857,9 +20801,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2019-08-09T00:00:00Z"
-  },
+  "date": "2019-08-09",
   "shares": 43,
   "amount": 9.32,
   "grossAmount": 0,
@@ -22879,9 +20821,7 @@
   "type": "Dividend",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2019-08-20T00:00:00Z"
-  },
+  "date": "2019-08-20",
   "shares": 129,
   "amount": 32.01,
   "grossAmount": 0,
@@ -22901,9 +20841,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2019-08-23T00:00:00Z"
-  },
+  "date": "2019-08-23",
   "shares": 228,
   "amount": 25.67,
   "grossAmount": 0,
@@ -22923,9 +20861,7 @@
   "type": "Dividend",
   "company": "HDFC BANK LTD ADR/3 IR 10",
   "symbol": "HDB",
-  "date": {
-    "$date": "2019-08-23T00:00:00Z"
-  },
+  "date": "2019-08-23",
   "shares": 56,
   "amount": 3.22,
   "grossAmount": 0,
@@ -22945,9 +20881,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2019-09-10T00:00:00Z"
-  },
+  "date": "2019-09-10",
   "shares": 50,
   "amount": 31.72,
   "grossAmount": 0,
@@ -22967,9 +20901,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2019-09-11T00:00:00Z"
-  },
+  "date": "2019-09-11",
   "shares": 135,
   "amount": 40.9,
   "grossAmount": 0,
@@ -22989,9 +20921,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2019-09-12T00:00:00Z"
-  },
+  "date": "2019-09-12",
   "shares": 75,
   "amount": 22.88,
   "grossAmount": 0,
@@ -23011,9 +20941,7 @@
   "type": "Dividend",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2019-09-24T00:00:00Z"
-  },
+  "date": "2019-09-24",
   "shares": 30,
   "amount": 21.8,
   "grossAmount": 0,
@@ -23033,9 +20961,7 @@
   "type": "Dividend",
   "company": "AIA GROUP LTD",
   "symbol": "1299.HK",
-  "date": {
-    "$date": "2019-09-26T00:00:00Z"
-  },
+  "date": "2019-09-26",
   "shares": 480,
   "amount": 13.39,
   "grossAmount": 0,
@@ -23055,9 +20981,7 @@
   "type": "Dividend",
   "company": "RECKITT BENCK.GRP LS -,10",
   "symbol": "RB.L",
-  "date": {
-    "$date": "2019-09-26T00:00:00Z"
-  },
+  "date": "2019-09-26",
   "shares": 60,
   "amount": 35.44,
   "grossAmount": 0,
@@ -23077,9 +21001,7 @@
   "type": "Dividend",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2019-09-25T00:00:00Z"
-  },
+  "date": "2019-09-25",
   "shares": 15,
   "amount": 7.58,
   "grossAmount": 0,
@@ -23099,9 +21021,7 @@
   "type": "Dividend",
   "company": "NIKE INC. B",
   "symbol": "NKE",
-  "date": {
-    "$date": "2019-09-30T00:00:00Z"
-  },
+  "date": "2019-09-30",
   "shares": 60,
   "amount": 8.93,
   "grossAmount": 0,
@@ -23121,9 +21041,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2019-09-30T00:00:00Z"
-  },
+  "date": "2019-09-30",
   "shares": 288,
   "amount": 17.9,
   "grossAmount": 0,
@@ -23143,9 +21061,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2019-10-07T00:00:00Z"
-  },
+  "date": "2019-10-07",
   "shares": 239,
   "amount": 81.99,
   "grossAmount": 0,
@@ -23165,9 +21081,7 @@
   "type": "Dividend",
   "company": "ECOLAB INC. DL 1",
   "symbol": "ECL",
-  "date": {
-    "$date": "2019-10-15T00:00:00Z"
-  },
+  "date": "2019-10-15",
   "shares": 18,
   "amount": 5.53,
   "grossAmount": 0,
@@ -23187,9 +21101,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2019-10-17T00:00:00Z"
-  },
+  "date": "2019-10-17",
   "shares": 50,
   "amount": 31.52,
   "grossAmount": 0,
@@ -23209,9 +21121,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2019-10-24T00:00:00Z"
-  },
+  "date": "2019-10-24",
   "shares": 139,
   "amount": 22.15,
   "grossAmount": 0,
@@ -23231,9 +21141,7 @@
   "type": "Dividend",
   "company": "INTUIT INC. DL-,01",
   "symbol": "INTU",
-  "date": {
-    "$date": "2019-10-18T00:00:00Z"
-  },
+  "date": "2019-10-18",
   "shares": 22,
   "amount": 7.72,
   "grossAmount": 0,
@@ -23253,9 +21161,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2019-11-08T00:00:00Z"
-  },
+  "date": "2019-11-08",
   "shares": 43,
   "amount": 9.48,
   "grossAmount": 0,
@@ -23275,9 +21181,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2019-11-14T00:00:00Z"
-  },
+  "date": "2019-11-14",
   "shares": 209,
   "amount": 45.98,
   "grossAmount": 0,
@@ -23297,9 +21201,7 @@
   "type": "Dividend",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2019-11-15T00:00:00Z"
-  },
+  "date": "2019-11-15",
   "shares": 32,
   "amount": 12.01,
   "grossAmount": 0,
@@ -23319,9 +21221,7 @@
   "type": "Dividend",
   "company": "KEYENCE CORP.",
   "symbol": "6861.T",
-  "date": {
-    "$date": "2019-11-21T00:00:00Z"
-  },
+  "date": "2019-11-21",
   "shares": 18,
   "amount": 5.49,
   "grossAmount": 0,
@@ -23341,9 +21241,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2019-11-22T00:00:00Z"
-  },
+  "date": "2019-11-22",
   "shares": 228,
   "amount": 25.94,
   "grossAmount": 0,
@@ -23363,9 +21261,7 @@
   "type": "Dividend",
   "company": "ZOETIS INC. CL.A DL -,01",
   "symbol": "ZTS",
-  "date": {
-    "$date": "2019-12-02T00:00:00Z"
-  },
+  "date": "2019-12-02",
   "shares": 23,
   "amount": 2.52,
   "grossAmount": 0,
@@ -23385,9 +21281,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2019-12-04T00:00:00Z"
-  },
+  "date": "2019-12-04",
   "shares": 135,
   "amount": 40.9,
   "grossAmount": 0,
@@ -23407,9 +21301,7 @@
   "type": "Dividend",
   "company": "LVMH EO 0,3",
   "symbol": "MC.PA",
-  "date": {
-    "$date": "2019-12-10T00:00:00Z"
-  },
+  "date": "2019-12-10",
   "shares": 10,
   "amount": 12.41,
   "grossAmount": 0,
@@ -23429,9 +21321,7 @@
   "type": "Dividend",
   "company": "COLOPLAST NAM. B DK 1",
   "symbol": "COLO-B.CO",
-  "date": {
-    "$date": "2019-12-10T00:00:00Z"
-  },
+  "date": "2019-12-10",
   "shares": 53,
   "amount": 52.47,
   "grossAmount": 0,
@@ -23451,9 +21341,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2019-12-12T00:00:00Z"
-  },
+  "date": "2019-12-12",
   "shares": 75,
   "amount": 25.26,
   "grossAmount": 0,
@@ -23473,9 +21361,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2019-12-10T00:00:00Z"
-  },
+  "date": "2019-12-10",
   "shares": 50,
   "amount": 31.42,
   "grossAmount": 0,
@@ -23495,9 +21381,7 @@
   "type": "Dividend",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2019-12-17T00:00:00Z"
-  },
+  "date": "2019-12-17",
   "shares": 30,
   "amount": 21.41,
   "grossAmount": 0,
@@ -23517,9 +21401,7 @@
   "type": "Dividend",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2019-12-27T00:00:00Z"
-  },
+  "date": "2019-12-27",
   "shares": 20,
   "amount": 9.92,
   "grossAmount": 0,
@@ -23539,9 +21421,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2019-12-31T00:00:00Z"
-  },
+  "date": "2019-12-31",
   "shares": 288,
   "amount": 17.69,
   "grossAmount": 0,
@@ -23561,9 +21441,7 @@
   "type": "Dividend",
   "company": "NIKE INC. B",
   "symbol": "NKE",
-  "date": {
-    "$date": "2020-01-02T00:00:00Z"
-  },
+  "date": "2020-01-02",
   "shares": 60,
   "amount": 9.68,
   "grossAmount": 0,
@@ -23583,9 +21461,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2020-01-14T00:00:00Z"
-  },
+  "date": "2020-01-14",
   "shares": 50,
   "amount": 38.38,
   "grossAmount": 0,
@@ -23605,9 +21481,7 @@
   "type": "Dividend",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2020-01-15T00:00:00Z"
-  },
+  "date": "2020-01-15",
   "shares": 25,
   "amount": 45.09,
   "grossAmount": 0,
@@ -23627,9 +21501,7 @@
   "type": "Dividend",
   "company": "ECOLAB INC. DL 1",
   "symbol": "ECL",
-  "date": {
-    "$date": "2020-01-15T00:00:00Z"
-  },
+  "date": "2020-01-15",
   "shares": 18,
   "amount": 6.43,
   "grossAmount": 0,
@@ -23649,9 +21521,7 @@
   "type": "Dividend",
   "company": "INTUIT INC. DL-,01",
   "symbol": "INTU",
-  "date": {
-    "$date": "2020-01-21T00:00:00Z"
-  },
+  "date": "2020-01-21",
   "shares": 22,
   "amount": 8.91,
   "grossAmount": 0,
@@ -23671,9 +21541,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2020-01-23T00:00:00Z"
-  },
+  "date": "2020-01-23",
   "shares": 139,
   "amount": 25.65,
   "grossAmount": 0,
@@ -23693,9 +21561,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2020-02-07T00:00:00Z"
-  },
+  "date": "2020-02-07",
   "shares": 43,
   "amount": 13.35,
   "grossAmount": 0,
@@ -23715,9 +21581,7 @@
   "type": "Dividend",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2020-02-14T00:00:00Z"
-  },
+  "date": "2020-02-14",
   "shares": 32,
   "amount": 17.67,
   "grossAmount": 0,
@@ -23737,9 +21601,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2020-02-28T00:00:00Z"
-  },
+  "date": "2020-02-28",
   "shares": 228,
   "amount": 31.41,
   "grossAmount": 0,
@@ -23759,9 +21621,7 @@
   "type": "Dividend",
   "company": "ZOETIS INC. CL.A DL -,01",
   "symbol": "ZTS",
-  "date": {
-    "$date": "2020-03-03T00:00:00Z"
-  },
+  "date": "2020-03-03",
   "shares": 28,
   "amount": 3.75,
   "grossAmount": 0,
@@ -23781,9 +21641,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2020-03-10T00:00:00Z"
-  },
+  "date": "2020-03-10",
   "shares": 50,
   "amount": 42.13,
   "grossAmount": 0,
@@ -23803,9 +21661,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 75,
   "amount": 34.04,
   "grossAmount": 0,
@@ -23825,9 +21681,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2020-03-18T00:00:00Z"
-  },
+  "date": "2020-03-18",
   "shares": 155,
   "amount": 63.61,
   "grossAmount": 0,
@@ -23847,9 +21701,7 @@
   "type": "Dividend",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2020-03-24T00:00:00Z"
-  },
+  "date": "2020-03-24",
   "shares": 30,
   "amount": 29.55,
   "grossAmount": 0,
@@ -23869,9 +21721,7 @@
   "type": "Dividend",
   "company": "ROCHE HLDG AG GEN.",
   "symbol": "ROG.SW",
-  "date": {
-    "$date": "2020-03-23T00:00:00Z"
-  },
+  "date": "2020-03-23",
   "shares": 15,
   "amount": 127.06,
   "grossAmount": 0,
@@ -23891,9 +21741,7 @@
   "type": "Dividend",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2020-03-25T00:00:00Z"
-  },
+  "date": "2020-03-25",
   "shares": 25,
   "amount": 19.87,
   "grossAmount": 0,
@@ -23913,9 +21761,7 @@
   "type": "Dividend",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2020-03-31T00:00:00Z"
-  },
+  "date": "2020-03-31",
   "shares": 129,
   "amount": 92.2,
   "grossAmount": 0,
@@ -23935,9 +21781,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2020-03-31T00:00:00Z"
-  },
+  "date": "2020-03-31",
   "shares": 288,
   "amount": 31.33,
   "grossAmount": 0,
@@ -23957,9 +21801,7 @@
   "type": "Dividend",
   "company": "NIKE INC. B",
   "symbol": "NKE",
-  "date": {
-    "$date": "2020-04-01T00:00:00Z"
-  },
+  "date": "2020-04-01",
   "shares": 60,
   "amount": 13.58,
   "grossAmount": 0,
@@ -23979,9 +21821,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2020-04-09T00:00:00Z"
-  },
+  "date": "2020-04-09",
   "shares": 239,
   "amount": 74.78,
   "grossAmount": 0,
@@ -24001,9 +21841,7 @@
   "type": "Dividend",
   "company": "ECOLAB INC. DL 1",
   "symbol": "ECL",
-  "date": {
-    "$date": "2020-04-15T00:00:00Z"
-  },
+  "date": "2020-04-15",
   "shares": 18,
   "amount": 7.79,
   "grossAmount": 0,
@@ -24023,9 +21861,7 @@
   "type": "Dividend",
   "company": "INTUIT INC. DL-,01",
   "symbol": "INTU",
-  "date": {
-    "$date": "2020-04-20T00:00:00Z"
-  },
+  "date": "2020-04-20",
   "shares": 22,
   "amount": 10.75,
   "grossAmount": 0,
@@ -24045,9 +21881,7 @@
   "type": "Dividend",
   "company": "Oracle",
   "symbol": "ORCL",
-  "date": {
-    "$date": "2020-04-23T00:00:00Z"
-  },
+  "date": "2020-04-23",
   "shares": 139,
   "amount": 30.64,
   "grossAmount": 0,
@@ -24067,9 +21901,7 @@
   "type": "Dividend",
   "company": "\"NESTLE NAM. SF-,10 \"",
   "symbol": "NESN.SW",
-  "date": {
-    "$date": "2020-04-29T00:00:00Z"
-  },
+  "date": "2020-04-29",
   "shares": 94,
   "amount": 239.47,
   "grossAmount": 0,
@@ -24089,9 +21921,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2020-04-29T00:00:00Z"
-  },
+  "date": "2020-04-29",
   "shares": 50,
   "amount": 49.04,
   "grossAmount": 0,
@@ -24111,9 +21941,7 @@
   "type": "Dividend",
   "company": "HEINEKEN HLDG EO 1,60",
   "symbol": "HEIO.AS",
-  "date": {
-    "$date": "2020-05-07T00:00:00Z"
-  },
+  "date": "2020-05-07",
   "shares": 80,
   "amount": 83.2,
   "grossAmount": 0,
@@ -24133,9 +21961,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2020-05-08T00:00:00Z"
-  },
+  "date": "2020-05-08",
   "shares": 43,
   "amount": 15.87,
   "grossAmount": 0,
@@ -24155,9 +21981,7 @@
   "type": "Dividend",
   "company": "COLOPLAST NAM. B DK 1",
   "symbol": "COLO-B.CO",
-  "date": {
-    "$date": "2020-05-13T00:00:00Z"
-  },
+  "date": "2020-05-13",
   "shares": 53,
   "amount": 35.44,
   "grossAmount": 0,
@@ -24177,9 +22001,7 @@
   "type": "Dividend",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2020-05-15T00:00:00Z"
-  },
+  "date": "2020-05-15",
   "shares": 32,
   "amount": 23.26,
   "grossAmount": 0,
@@ -24199,9 +22021,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2020-05-22T00:00:00Z"
-  },
+  "date": "2020-05-22",
   "shares": 243,
   "amount": 39.93,
   "grossAmount": 0,
@@ -24221,9 +22041,7 @@
   "type": "Dividend",
   "company": "RECKITT BENCK.GRP LS -,10",
   "symbol": "RB.L",
-  "date": {
-    "$date": "2020-05-28T00:00:00Z"
-  },
+  "date": "2020-05-28",
   "shares": 83,
   "amount": 92.94,
   "grossAmount": 0,
@@ -24243,9 +22061,7 @@
   "type": "Dividend",
   "company": "ZOETIS INC. CL.A DL -,01",
   "symbol": "ZTS",
-  "date": {
-    "$date": "2020-06-01T00:00:00Z"
-  },
+  "date": "2020-06-01",
   "shares": 28,
   "amount": 5.08,
   "grossAmount": 0,
@@ -24265,9 +22081,7 @@
   "type": "Dividend",
   "company": "DASSAULT SYS SA INH.EO0,5",
   "symbol": "DSY.PA",
-  "date": {
-    "$date": "2020-06-02T00:00:00Z"
-  },
+  "date": "2020-06-02",
   "shares": 20,
   "amount": 14,
   "grossAmount": 0,
@@ -24287,9 +22101,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2020-06-04T00:00:00Z"
-  },
+  "date": "2020-06-04",
   "shares": 155,
   "amount": 63.61,
   "grossAmount": 0,
@@ -24309,9 +22121,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2020-06-09T00:00:00Z"
-  },
+  "date": "2020-06-09",
   "shares": 50,
   "amount": 44.23,
   "grossAmount": 0,
@@ -24331,9 +22141,7 @@
   "type": "Dividend",
   "company": "Intertek",
   "symbol": "ITRK.L",
-  "date": {
-    "$date": "2020-06-11T00:00:00Z"
-  },
+  "date": "2020-06-11",
   "shares": 20,
   "amount": 16.1,
   "grossAmount": 0,
@@ -24353,9 +22161,7 @@
   "type": "Dividend",
   "company": "KEYENCE CORP.",
   "symbol": "6861.T",
-  "date": {
-    "$date": "2020-06-15T00:00:00Z"
-  },
+  "date": "2020-06-15",
   "shares": 18,
   "amount": 14.76,
   "grossAmount": 0,
@@ -24375,9 +22181,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2020-06-11T00:00:00Z"
-  },
+  "date": "2020-06-11",
   "shares": 75,
   "amount": 33.72,
   "grossAmount": 0,
@@ -24397,9 +22201,7 @@
   "type": "Dividend",
   "company": "AIA GROUP LTD",
   "symbol": "1299.HK",
-  "date": {
-    "$date": "2020-06-19T00:00:00Z"
-  },
+  "date": "2020-06-19",
   "shares": 480,
   "amount": 51.31,
   "grossAmount": 0,
@@ -24419,9 +22221,7 @@
   "type": "Dividend",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2020-06-25T00:00:00Z"
-  },
+  "date": "2020-06-25",
   "shares": 25,
   "amount": 18.76,
   "grossAmount": 0,
@@ -24441,9 +22241,7 @@
   "type": "Dividend",
   "company": "\"INVESTOR A (FRIA) SK6,25 \"",
   "symbol": "INVE-A.ST",
-  "date": {
-    "$date": "2020-06-25T00:00:00Z"
-  },
+  "date": "2020-06-25",
   "shares": 209,
   "amount": 178.78,
   "grossAmount": 0,
@@ -24463,9 +22261,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2020-06-30T00:00:00Z"
-  },
+  "date": "2020-06-30",
   "shares": 288,
   "amount": 30.47,
   "grossAmount": 0,
@@ -24485,9 +22281,7 @@
   "type": "Dividend",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2020-06-30T00:00:00Z"
-  },
+  "date": "2020-06-30",
   "shares": 30,
   "amount": 33.41,
   "grossAmount": 0,
@@ -24507,9 +22301,7 @@
   "type": "Dividend",
   "company": "NIKE INC. B",
   "symbol": "NKE",
-  "date": {
-    "$date": "2020-07-01T00:00:00Z"
-  },
+  "date": "2020-07-01",
   "shares": 60,
   "amount": 12.98,
   "grossAmount": 0,
@@ -24529,9 +22321,7 @@
   "type": "Dividend",
   "company": "OREAL (L') INH. EO 0,2",
   "symbol": "OR.PA",
-  "date": {
-    "$date": "2020-07-07T00:00:00Z"
-  },
+  "date": "2020-07-07",
   "shares": 22,
   "amount": 84.7,
   "grossAmount": 0,
@@ -24551,9 +22341,7 @@
   "type": "Dividend",
   "company": "LVMH EO 0,3",
   "symbol": "MC.PA",
-  "date": {
-    "$date": "2020-07-09T00:00:00Z"
-  },
+  "date": "2020-07-09",
   "shares": 10,
   "amount": 26,
   "grossAmount": 0,
@@ -24573,9 +22361,7 @@
   "type": "Dividend",
   "company": "AMERICAN TOWER DL -,01",
   "symbol": "AMT",
-  "date": {
-    "$date": "2020-07-10T00:00:00Z"
-  },
+  "date": "2020-07-10",
   "shares": 50,
   "amount": 48.67,
   "grossAmount": 0,
@@ -24595,9 +22381,7 @@
   "type": "Dividend",
   "company": "ECOLAB INC. DL 1",
   "symbol": "ECL",
-  "date": {
-    "$date": "2020-07-15T00:00:00Z"
-  },
+  "date": "2020-07-15",
   "shares": 18,
   "amount": 7.4,
   "grossAmount": 0,
@@ -24617,9 +22401,7 @@
   "type": "Dividend",
   "company": "\"MASTERCARD INC.A DL-,0001 \"",
   "symbol": "MA",
-  "date": {
-    "$date": "2020-08-07T00:00:00Z"
-  },
+  "date": "2020-08-07",
   "shares": 43,
   "amount": 14.53,
   "grossAmount": 0,
@@ -24639,9 +22421,7 @@
   "type": "Dividend",
   "company": "INTUIT INC. DL-,01",
   "symbol": "INTU",
-  "date": {
-    "$date": "2020-07-20T00:00:00Z"
-  },
+  "date": "2020-07-20",
   "shares": 22,
   "amount": 10.17,
   "grossAmount": 0,
@@ -24661,9 +22441,7 @@
   "type": "Dividend",
   "company": "ACCENTURE A DL-,0000225",
   "symbol": "ACN",
-  "date": {
-    "$date": "2020-08-14T00:00:00Z"
-  },
+  "date": "2020-08-14",
   "shares": 32,
   "amount": 21.39,
   "grossAmount": 0,
@@ -24683,9 +22461,7 @@
   "type": "Dividend",
   "company": "NOVO-NORDISK NAM.B DK-,20",
   "symbol": "Novo-B.CO",
-  "date": {
-    "$date": "2020-08-18T00:00:00Z"
-  },
+  "date": "2020-08-18",
   "shares": 129,
   "amount": 56.14,
   "grossAmount": 0,
@@ -24705,9 +22481,7 @@
   "type": "Dividend",
   "company": "CHARLES SCHWAB CORP.DL-01",
   "symbol": "SCHW",
-  "date": {
-    "$date": "2020-08-28T00:00:00Z"
-  },
+  "date": "2020-08-28",
   "shares": 243,
   "amount": 36.97,
   "grossAmount": 0,
@@ -24727,9 +22501,7 @@
   "type": "Dividend",
   "company": "ZOETIS INC. CL.A DL -,01",
   "symbol": "ZTS",
-  "date": {
-    "$date": "2020-09-01T00:00:00Z"
-  },
+  "date": "2020-09-01",
   "shares": 28,
   "amount": 4.7,
   "grossAmount": 0,
@@ -24749,9 +22521,7 @@
   "type": "Dividend",
   "company": "UNILEVER NAM. EO -,16",
   "symbol": "UNA.AS",
-  "date": {
-    "$date": "2020-09-09T00:00:00Z"
-  },
+  "date": "2020-09-09",
   "shares": 155,
   "amount": 63.61,
   "grossAmount": 0,
@@ -24771,9 +22541,7 @@
   "type": "Dividend",
   "company": "JOHNSON + JOHNSON DL 1",
   "symbol": "JNJ",
-  "date": {
-    "$date": "2020-09-08T00:00:00Z"
-  },
+  "date": "2020-09-08",
   "shares": 50,
   "amount": 42.59,
   "grossAmount": 0,
@@ -24793,9 +22561,7 @@
   "type": "Dividend",
   "company": "AIA GROUP LTD",
   "symbol": "1299.HK",
-  "date": {
-    "$date": "2020-09-24T00:00:00Z"
-  },
+  "date": "2020-09-24",
   "shares": 610,
   "amount": 23.4,
   "grossAmount": 0,
@@ -24815,9 +22581,7 @@
   "type": "Dividend",
   "company": "MICROSOFT DL-,00000625",
   "symbol": "MSFT",
-  "date": {
-    "$date": "2020-09-10T00:00:00Z"
-  },
+  "date": "2020-09-10",
   "shares": 75,
   "amount": 32.13,
   "grossAmount": 0,
@@ -24837,9 +22601,7 @@
   "type": "Dividend",
   "company": "UNITEDHEALTH GROUP DL-,01",
   "symbol": "UNH",
-  "date": {
-    "$date": "2020-09-22T00:00:00Z"
-  },
+  "date": "2020-09-22",
   "shares": 30,
   "amount": 32.15,
   "grossAmount": 0,
@@ -24859,9 +22621,7 @@
   "type": "Dividend",
   "company": "CME GROUP INC. DL-,01",
   "symbol": "CME",
-  "date": {
-    "$date": "2020-09-25T00:00:00Z"
-  },
+  "date": "2020-09-25",
   "shares": 32,
   "amount": 23.24,
   "grossAmount": 0,
@@ -24881,9 +22641,7 @@
   "type": "Dividend",
   "company": "PEPSICO INC. DL-,0166",
   "symbol": "PEP",
-  "date": {
-    "$date": "2020-09-30T00:00:00Z"
-  },
+  "date": "2020-09-30",
   "shares": 9,
   "amount": 7.88,
   "grossAmount": 0,
@@ -24903,9 +22661,7 @@
   "type": "Dividend",
   "company": "RECKITT BENCK.GRP LS -,10",
   "symbol": "RB.L",
-  "date": {
-    "$date": "2020-09-29T00:00:00Z"
-  },
+  "date": "2020-09-29",
   "shares": 83,
   "amount": 66.14,
   "grossAmount": 0,
@@ -24925,9 +22681,7 @@
   "type": "Dividend",
   "company": "BROOKFIELD ASSET MAN.A LV",
   "symbol": "BAM",
-  "date": {
-    "$date": "2020-09-30T00:00:00Z"
-  },
+  "date": "2020-09-30",
   "shares": 288,
   "amount": 28.95,
   "grossAmount": 0,
@@ -24947,9 +22701,7 @@
   "type": "Dividend",
   "company": "NIKE INC. B",
   "symbol": "NKE",
-  "date": {
-    "$date": "2020-10-01T00:00:00Z"
-  },
+  "date": "2020-10-01",
   "shares": 60,
   "amount": 12.49,
   "grossAmount": 0,
@@ -24969,9 +22721,7 @@
   "type": "Dividend",
   "company": "DIAGEO PLC LS-,28935185",
   "symbol": "DGE.L",
-  "date": {
-    "$date": "2020-10-08T00:00:00Z"
-  },
+  "date": "2020-10-08",
   "shares": 239,
   "amount": 110.98,
   "grossAmount": 0,
@@ -24991,9 +22741,7 @@
   "type": "Dividend",
   "company": "Canadian National Railway",
   "symbol": "CNI",
-  "date": {
-    "$date": "2019-12-30T00:00:00Z"
-  },
+  "date": "2019-12-30",
   "shares": 50,
   "amount": 11.76,
   "grossAmount": 0,
@@ -25013,9 +22761,7 @@
   "type": "Dividend",
   "company": "\"CK Asset Holdings \"",
   "symbol": "1113.HK",
-  "date": {
-    "$date": "2015-10-06T00:00:00Z"
-  },
+  "date": "2015-10-06",
   "shares": 490,
   "amount": 14.2,
   "grossAmount": 0,
@@ -25035,9 +22781,7 @@
   "type": "Dividend",
   "company": "\"CK Asset Holdings \"",
   "symbol": "1113.HK",
-  "date": {
-    "$date": "2016-06-01T00:00:00Z"
-  },
+  "date": "2016-06-01",
   "shares": 490,
   "amount": 42.61,
   "grossAmount": 0,
@@ -25057,9 +22801,7 @@
   "type": "Dividend",
   "company": "\"CK Asset Holdings \"",
   "symbol": "1113.HK",
-  "date": {
-    "$date": "2016-09-22T00:00:00Z"
-  },
+  "date": "2016-09-22",
   "shares": 490,
   "amount": 15.35,
   "grossAmount": 0,
@@ -25079,9 +22821,7 @@
   "type": "Dividend",
   "company": "\"CK Asset Holdings \"",
   "symbol": "1113.HK",
-  "date": {
-    "$date": "2017-09-14T00:00:00Z"
-  },
+  "date": "2017-09-14",
   "shares": 490,
   "amount": 15.9,
   "grossAmount": 0,
@@ -25097,9 +22837,7 @@
     "$oid": "5f876f1633cdd600305396a6"
   },
   "type": "Buy",
-  "date": {
-    "$date": "2020-10-14T00:00:00Z"
-  },
+  "date": "2020-10-14",
   "isin": "US40171V1008",
   "company": "Guidewire Software Inc.",
   "shares": 10,
@@ -25118,9 +22856,7 @@
   "type": "Buy",
   "company": "ILLUMINA INC. DL-,01",
   "symbol": "ILMN",
-  "date": {
-    "$date": "2019-11-07T00:00:00Z"
-  },
+  "date": "2019-11-07",
   "shares": 9,
   "amount": 2398.15,
   "grossAmount": 2659.55,
@@ -25141,9 +22877,7 @@
   "type": "Buy",
   "company": "ILLUMINA INC. DL-,01",
   "symbol": "ILMN",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 3,
   "amount": 609,
   "grossAmount": 609,
@@ -25164,9 +22898,7 @@
   "type": "Buy",
   "company": "ILLUMINA INC. DL-,01",
   "symbol": "ILMN",
-  "date": {
-    "$date": "2020-02-13T00:00:00Z"
-  },
+  "date": "2020-02-13",
   "shares": 2,
   "amount": 537.6,
   "grossAmount": 584.21,
@@ -25187,9 +22919,7 @@
   "type": "Buy",
   "company": "CTS Eventim",
   "symbol": "EVD.DE",
-  "date": {
-    "$date": "2020-01-27T00:00:00Z"
-  },
+  "date": "2020-01-27",
   "shares": 9,
   "amount": 541,
   "grossAmount": 0,
@@ -25210,9 +22940,7 @@
   "type": "Buy",
   "company": "INTUITIVE SURGIC. DL-,001",
   "symbol": "ISRG",
-  "date": {
-    "$date": "2020-01-24T00:00:00Z"
-  },
+  "date": "2020-01-24",
   "shares": 2,
   "amount": 1077.4,
   "grossAmount": 1194.94,
@@ -25233,9 +22961,7 @@
   "type": "Buy",
   "company": "ILLUMINA INC. DL-,01",
   "symbol": "ILMN",
-  "date": {
-    "$date": "2020-01-14T00:00:00Z"
-  },
+  "date": "2020-01-14",
   "shares": 4,
   "amount": 1153.6,
   "grossAmount": 1283.5,
@@ -25256,9 +22982,7 @@
   "type": "Buy",
   "company": "ILLUMINA INC. DL-,01",
   "symbol": "ILMN",
-  "date": {
-    "$date": "2020-02-25T00:00:00Z"
-  },
+  "date": "2020-02-25",
   "shares": 2,
   "amount": 506.8,
   "grossAmount": 549.37,
@@ -25279,9 +23003,7 @@
   "type": "Buy",
   "company": "INTUITIVE SURGIC. DL-,001",
   "symbol": "ISRG",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 2,
   "amount": 878,
   "grossAmount": 878,
@@ -25302,9 +23024,7 @@
   "type": "Buy",
   "company": "INTUITIVE SURGIC. DL-,001",
   "symbol": "ISRG",
-  "date": {
-    "$date": "2020-01-07T00:00:00Z"
-  },
+  "date": "2020-01-07",
   "shares": 2,
   "amount": 1034.4,
   "grossAmount": 1157.91,
@@ -25325,9 +23045,7 @@
   "type": "Buy",
   "company": "INTUITIVE SURGIC. DL-,001",
   "symbol": "ISRG",
-  "date": {
-    "$date": "2020-02-28T00:00:00Z"
-  },
+  "date": "2020-02-28",
   "shares": 1,
   "amount": 479.4,
   "grossAmount": 525.61,
@@ -25348,9 +23066,7 @@
   "type": "Buy",
   "company": "CTS Eventim",
   "symbol": "EVD.DE",
-  "date": {
-    "$date": "2020-01-30T00:00:00Z"
-  },
+  "date": "2020-01-30",
   "shares": 10,
   "amount": 565,
   "grossAmount": 0,
@@ -25371,9 +23087,7 @@
   "type": "Buy",
   "company": "CTS Eventim",
   "symbol": "EVD.DE",
-  "date": {
-    "$date": "2020-02-24T00:00:00Z"
-  },
+  "date": "2020-02-24",
   "shares": 10,
   "amount": 520.5,
   "grossAmount": 0,
@@ -25394,9 +23108,7 @@
   "type": "Buy",
   "company": "CTS Eventim",
   "symbol": "EVD.DE",
-  "date": {
-    "$date": "2020-03-05T00:00:00Z"
-  },
+  "date": "2020-03-05",
   "shares": 11,
   "amount": 503.26,
   "grossAmount": 0,
@@ -25417,9 +23129,7 @@
   "type": "Buy",
   "company": "CTS Eventim",
   "symbol": "EVD.DE",
-  "date": {
-    "$date": "2020-03-18T00:00:00Z"
-  },
+  "date": "2020-03-18",
   "shares": 36,
   "amount": 989.28,
   "grossAmount": 0,
@@ -25440,9 +23150,7 @@
   "type": "Sell",
   "company": "CTS Eventim",
   "symbol": "EVD.DE",
-  "date": {
-    "$date": "2020-06-23T00:00:00Z"
-  },
+  "date": "2020-06-23",
   "shares": 76,
   "amount": 2945.76,
   "grossAmount": 0,
@@ -25463,9 +23171,7 @@
   "type": "Buy",
   "company": "MTU Aero Engines",
   "symbol": "MTX.DE",
-  "date": {
-    "$date": "2020-01-27T00:00:00Z"
-  },
+  "date": "2020-01-27",
   "shares": 2,
   "amount": 556.8,
   "grossAmount": 0,
@@ -25486,9 +23192,7 @@
   "type": "Buy",
   "company": "MTU Aero Engines",
   "symbol": "MTX.DE",
-  "date": {
-    "$date": "2020-02-05T00:00:00Z"
-  },
+  "date": "2020-02-05",
   "shares": 4,
   "amount": 1078.2,
   "grossAmount": 0,
@@ -25509,9 +23213,7 @@
   "type": "Buy",
   "company": "MTU Aero Engines",
   "symbol": "MTX.DE",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 6,
   "amount": 972,
   "grossAmount": 0,
@@ -25532,9 +23234,7 @@
   "type": "Buy",
   "company": "MTU Aero Engines",
   "symbol": "MTX.DE",
-  "date": {
-    "$date": "2020-03-18T00:00:00Z"
-  },
+  "date": "2020-03-18",
   "shares": 10,
   "amount": 979.6,
   "grossAmount": 0,
@@ -25555,9 +23255,7 @@
   "type": "Buy",
   "company": "MTU Aero Engines",
   "symbol": "MTX.DE",
-  "date": {
-    "$date": "2020-02-25T00:00:00Z"
-  },
+  "date": "2020-02-25",
   "shares": 2,
   "amount": 476.6,
   "grossAmount": 0,
@@ -25578,9 +23276,7 @@
   "type": "Sell",
   "company": "MTU Aero Engines",
   "symbol": "MTX.DE",
-  "date": {
-    "$date": "2020-06-08T00:00:00Z"
-  },
+  "date": "2020-06-08",
   "shares": 24,
   "amount": 4304.98,
   "grossAmount": 0,
@@ -25601,9 +23297,7 @@
   "type": "Buy",
   "company": "Orpea",
   "symbol": "ORP.PA",
-  "date": {
-    "$date": "2020-01-27T00:00:00Z"
-  },
+  "date": "2020-01-27",
   "shares": 5,
   "amount": 567.19,
   "grossAmount": 0,
@@ -25624,9 +23318,7 @@
   "type": "Buy",
   "company": "Orpea",
   "symbol": "ORP.PA",
-  "date": {
-    "$date": "2020-03-10T00:00:00Z"
-  },
+  "date": "2020-03-10",
   "shares": 5,
   "amount": 531.59,
   "grossAmount": 0,
@@ -25647,9 +23339,7 @@
   "type": "Buy",
   "company": "Orpea",
   "symbol": "ORP.PA",
-  "date": {
-    "$date": "2020-03-17T00:00:00Z"
-  },
+  "date": "2020-03-17",
   "shares": 7,
   "amount": 522.36,
   "grossAmount": 0,
@@ -25670,9 +23360,7 @@
   "type": "Sell",
   "company": "Orpea",
   "symbol": "ORP.PA",
-  "date": {
-    "$date": "2020-06-23T00:00:00Z"
-  },
+  "date": "2020-06-23",
   "shares": 17,
   "amount": 1801.15,
   "grossAmount": 0,
@@ -25693,9 +23381,7 @@
   "type": "Buy",
   "company": "TYLER TECHS INC. DL-,01",
   "symbol": "TYL",
-  "date": {
-    "$date": "2020-01-30T00:00:00Z"
-  },
+  "date": "2020-01-30",
   "shares": 2,
   "amount": 577,
   "grossAmount": 634.76,
@@ -25716,9 +23402,7 @@
   "type": "Buy",
   "company": "TYLER TECHS INC. DL-,01",
   "symbol": "TYL",
-  "date": {
-    "$date": "2020-03-10T00:00:00Z"
-  },
+  "date": "2020-03-10",
   "shares": 2,
   "amount": 537,
   "grossAmount": 615.19,
@@ -25739,9 +23423,7 @@
   "type": "Buy",
   "company": "TYLER TECHS INC. DL-,01",
   "symbol": "TYL",
-  "date": {
-    "$date": "2020-09-14T00:00:00Z"
-  },
+  "date": "2020-09-14",
   "shares": 4,
   "amount": 1112,
   "grossAmount": 1318.16,
@@ -25762,9 +23444,7 @@
   "type": "Buy",
   "company": "Fox Factory Holding",
   "symbol": "FOXF",
-  "date": {
-    "$date": "2020-03-06T00:00:00Z"
-  },
+  "date": "2020-03-06",
   "shares": 10,
   "amount": 546,
   "grossAmount": 610.81,
@@ -25785,9 +23465,7 @@
   "type": "Buy",
   "company": "Fox Factory Holding",
   "symbol": "FOXF",
-  "date": {
-    "$date": "2020-01-31T00:00:00Z"
-  },
+  "date": "2020-01-31",
   "shares": 9,
   "amount": 545.5,
   "grossAmount": 601.63,
@@ -25808,9 +23486,7 @@
   "type": "Buy",
   "company": "Fox Factory Holding",
   "symbol": "FOXF",
-  "date": {
-    "$date": "2020-03-16T00:00:00Z"
-  },
+  "date": "2020-03-16",
   "shares": 12,
   "amount": 516,
   "grossAmount": 516,
@@ -25831,9 +23507,7 @@
   "type": "Sell",
   "company": "Fox Factory Holding",
   "symbol": "FOXF",
-  "date": {
-    "$date": "2020-05-12T00:00:00Z"
-  },
+  "date": "2020-05-12",
   "shares": 31,
   "amount": 1658.5,
   "grossAmount": 1658.5,
@@ -25854,9 +23528,7 @@
   "type": "Buy",
   "company": "Neogen",
   "symbol": "NEOG",
-  "date": {
-    "$date": "2020-02-03T00:00:00Z"
-  },
+  "date": "2020-02-03",
   "shares": 8,
   "amount": 505,
   "grossAmount": 558.83,
@@ -25877,9 +23549,7 @@
   "type": "Buy",
   "company": "Neogen",
   "symbol": "NEOG",
-  "date": {
-    "$date": "2020-03-06T00:00:00Z"
-  },
+  "date": "2020-03-06",
   "shares": 9,
   "amount": 505,
   "grossAmount": 564.94,
@@ -25900,9 +23570,7 @@
   "type": "Sell",
   "company": "Neogen",
   "symbol": "NEOG",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 17,
   "amount": 1079.5,
   "grossAmount": 1219.24,
@@ -25923,9 +23591,7 @@
   "type": "Buy",
   "company": "Pros Holding",
   "symbol": "PRO",
-  "date": {
-    "$date": "2020-02-07T00:00:00Z"
-  },
+  "date": "2020-02-07",
   "shares": 10,
   "amount": 526,
   "grossAmount": 578.76,
@@ -25946,9 +23612,7 @@
   "type": "Buy",
   "company": "Pros Holding",
   "symbol": "PRO",
-  "date": {
-    "$date": "2020-02-11T00:00:00Z"
-  },
+  "date": "2020-02-11",
   "shares": 10,
   "amount": 493,
   "grossAmount": 539.88,
@@ -25969,9 +23633,7 @@
   "type": "Buy",
   "company": "Pros Holding",
   "symbol": "PRO",
-  "date": {
-    "$date": "2020-03-11T00:00:00Z"
-  },
+  "date": "2020-03-11",
   "shares": 15,
   "amount": 502,
   "grossAmount": 569.07,
@@ -25992,9 +23654,7 @@
   "type": "Sell",
   "company": "Pros Holding",
   "symbol": "PRO",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 55,
   "amount": 2090,
   "grossAmount": 2377.38,
@@ -26015,9 +23675,7 @@
   "type": "Buy",
   "company": "Pros Holding",
   "symbol": "PRO",
-  "date": {
-    "$date": "2020-04-01T00:00:00Z"
-  },
+  "date": "2020-04-01",
   "shares": 20,
   "amount": 548,
   "grossAmount": 548,
@@ -26038,9 +23696,7 @@
   "type": "Buy",
   "company": "MONCLER S.P.A.",
   "symbol": "MONC.MI",
-  "date": {
-    "$date": "2020-02-17T00:00:00Z"
-  },
+  "date": "2020-02-17",
   "shares": 14,
   "amount": 533.28,
   "grossAmount": 0,
@@ -26061,9 +23717,7 @@
   "type": "Buy",
   "company": "MONCLER S.P.A.",
   "symbol": "MONC.MI",
-  "date": {
-    "$date": "2020-02-24T00:00:00Z"
-  },
+  "date": "2020-02-24",
   "shares": 15,
   "amount": 528.25,
   "grossAmount": 0,
@@ -26084,9 +23738,7 @@
   "type": "Buy",
   "company": "MONCLER S.P.A.",
   "symbol": "MONC.MI",
-  "date": {
-    "$date": "2020-03-09T00:00:00Z"
-  },
+  "date": "2020-03-09",
   "shares": 17,
   "amount": 521.71,
   "grossAmount": 0,
@@ -26107,9 +23759,7 @@
   "type": "Buy",
   "company": "PAYLOCITY HLDG DL-,001",
   "symbol": "PCTY",
-  "date": {
-    "$date": "2020-02-21T00:00:00Z"
-  },
+  "date": "2020-02-21",
   "shares": 4,
   "amount": 521,
   "grossAmount": 562.16,
@@ -26130,9 +23780,7 @@
   "type": "Buy",
   "company": "PAYLOCITY HLDG DL-,001",
   "symbol": "PCTY",
-  "date": {
-    "$date": "2020-02-28T00:00:00Z"
-  },
+  "date": "2020-02-28",
   "shares": 4,
   "amount": 461,
   "grossAmount": 505.44,
@@ -26153,9 +23801,7 @@
   "type": "Buy",
   "company": "PAYLOCITY HLDG DL-,001",
   "symbol": "PCTY",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 6,
   "amount": 543,
   "grossAmount": 543,
@@ -26176,9 +23822,7 @@
   "type": "Buy",
   "company": "PAYLOCITY HLDG DL-,001",
   "symbol": "PCTY",
-  "date": {
-    "$date": "2020-04-23T00:00:00Z"
-  },
+  "date": "2020-04-23",
   "shares": 7,
   "amount": 556.5,
   "grossAmount": 556.5,
@@ -26199,9 +23843,7 @@
   "type": "Buy",
   "company": "GLOBANT SA NOM. DL 1,20",
   "symbol": "GLOB",
-  "date": {
-    "$date": "2020-02-24T00:00:00Z"
-  },
+  "date": "2020-02-24",
   "shares": 13,
   "amount": 1497.21,
   "grossAmount": 1617.14,
@@ -26222,9 +23864,7 @@
   "type": "Buy",
   "company": "GLOBANT SA NOM. DL 1,20",
   "symbol": "GLOB",
-  "date": {
-    "$date": "2020-03-09T00:00:00Z"
-  },
+  "date": "2020-03-09",
   "shares": 17,
   "amount": 1479.03,
   "grossAmount": 1676.63,
@@ -26245,9 +23885,7 @@
   "type": "Buy",
   "company": "ADYEN N.V. EO-,01",
   "symbol": "ADYEN.AS",
-  "date": {
-    "$date": "2020-02-27T00:00:00Z"
-  },
+  "date": "2020-02-27",
   "shares": 1,
   "amount": 776,
   "grossAmount": 0,
@@ -26268,9 +23906,7 @@
   "type": "Buy",
   "company": "ADYEN N.V. EO-,01",
   "symbol": "ADYEN.AS",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 2,
   "amount": 1396,
   "grossAmount": 0,
@@ -26291,9 +23927,7 @@
   "type": "Buy",
   "company": "TREX CO. INC. DL-,01",
   "symbol": "TREX",
-  "date": {
-    "$date": "2020-04-01T00:00:00Z"
-  },
+  "date": "2020-04-01",
   "shares": 18,
   "amount": 616.5,
   "grossAmount": 616.5,
@@ -26314,9 +23948,7 @@
   "type": "Buy",
   "company": "Dechra Pharmaceuticals",
   "symbol": "DPH.L",
-  "date": {
-    "$date": "2020-04-09T00:00:00Z"
-  },
+  "date": "2020-04-09",
   "shares": 25,
   "amount": 755.5,
   "grossAmount": 66444.75,
@@ -26337,9 +23969,7 @@
   "type": "Sell",
   "company": "Dechra Pharmaceuticals",
   "symbol": "DPH.L",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 25,
   "amount": 766.5,
   "grossAmount": 68310.5,
@@ -26360,9 +23990,7 @@
   "type": "Buy",
   "company": "MERCADOLIBRE INC. DL-,001",
   "symbol": "MELI",
-  "date": {
-    "$date": "2020-04-09T00:00:00Z"
-  },
+  "date": "2020-04-09",
   "shares": 2,
   "amount": 1014,
   "grossAmount": 1102.32,
@@ -26383,9 +24011,7 @@
   "type": "Buy",
   "company": "VEEVA SYSTEMS A DL-,00001",
   "symbol": "VEEV",
-  "date": {
-    "$date": "2020-04-09T00:00:00Z"
-  },
+  "date": "2020-04-09",
   "shares": 5,
   "amount": 745.3,
   "grossAmount": 809.92,
@@ -26406,9 +24032,7 @@
   "type": "Buy",
   "company": "TWILIO INC.",
   "symbol": "TWLO",
-  "date": {
-    "$date": "2020-04-21T00:00:00Z"
-  },
+  "date": "2020-04-21",
   "shares": 6,
   "amount": 563.4,
   "grossAmount": 563.4,
@@ -26429,9 +24053,7 @@
   "type": "Buy",
   "company": "OKTA INC. CL.A O.N.",
   "symbol": "OKTA",
-  "date": {
-    "$date": "2020-04-21T00:00:00Z"
-  },
+  "date": "2020-04-21",
   "shares": 4,
   "amount": 535.92,
   "grossAmount": 535.92,
@@ -26452,9 +24074,7 @@
   "type": "Buy",
   "company": "AMADEUS IT GRP SA EO 0,01",
   "symbol": "AMS.MC",
-  "date": {
-    "$date": "2020-04-24T00:00:00Z"
-  },
+  "date": "2020-04-24",
   "shares": 12,
   "amount": 516.24,
   "grossAmount": 0,
@@ -26475,9 +24095,7 @@
   "type": "Buy",
   "company": "COSTAR GROUP INC. DL-,01",
   "symbol": "CSGP",
-  "date": {
-    "$date": "2020-04-24T00:00:00Z"
-  },
+  "date": "2020-04-24",
   "shares": 2,
   "amount": 1100,
   "grossAmount": 1100,
@@ -26498,9 +24116,7 @@
   "type": "Buy",
   "company": "AMADEUS IT GRP SA EO 0,01",
   "symbol": "AMS.MC",
-  "date": {
-    "$date": "2020-05-12T00:00:00Z"
-  },
+  "date": "2020-05-12",
   "shares": 14,
   "amount": 533.26,
   "grossAmount": 0,
@@ -26521,9 +24137,7 @@
   "type": "Buy",
   "company": "IDEXX LABS INC. DL-,10",
   "symbol": "IDXX",
-  "date": {
-    "$date": "2020-04-24T00:00:00Z"
-  },
+  "date": "2020-04-24",
   "shares": 2,
   "amount": 502.8,
   "grossAmount": 502.8,
@@ -26544,9 +24158,7 @@
   "type": "Buy",
   "company": "BRIGHT HOR.FAM.SO.DL-,001",
   "symbol": "BFAM",
-  "date": {
-    "$date": "2020-05-14T00:00:00Z"
-  },
+  "date": "2020-05-14",
   "shares": 10,
   "amount": 925.92,
   "grossAmount": 996.58,
@@ -26567,9 +24179,7 @@
   "type": "Sell",
   "company": "BRIGHT HOR.FAM.SO.DL-,001",
   "symbol": "BFAM",
-  "date": {
-    "$date": "2020-08-28T00:00:00Z"
-  },
+  "date": "2020-08-28",
   "shares": 10,
   "amount": 1130,
   "grossAmount": 1334.08,
@@ -26590,9 +24200,7 @@
   "type": "Buy",
   "company": "ASSA-ABLOY AB B SK-,33",
   "symbol": "ASSA-B.ST",
-  "date": {
-    "$date": "2020-05-19T00:00:00Z"
-  },
+  "date": "2020-05-19",
   "shares": 30,
   "amount": 513.6,
   "grossAmount": 5449.5,
@@ -26613,9 +24221,7 @@
   "type": "Sell",
   "company": "ASSA-ABLOY AB B SK-,33",
   "symbol": "ASSA-B.ST",
-  "date": {
-    "$date": "2020-10-05T00:00:00Z"
-  },
+  "date": "2020-10-05",
   "shares": 30,
   "amount": 612,
   "grossAmount": 6380.1,
@@ -26636,9 +24242,7 @@
   "type": "Buy",
   "company": "SITEO.LANDS.SUPP.INC.-,01",
   "symbol": "SITE",
-  "date": {
-    "$date": "2020-05-29T00:00:00Z"
-  },
+  "date": "2020-05-29",
   "shares": 6,
   "amount": 564,
   "grossAmount": 629.82,
@@ -26659,9 +24263,7 @@
   "type": "Buy",
   "company": "SHOPIFY A SUB.VTG",
   "symbol": "SHOP",
-  "date": {
-    "$date": "2020-06-03T00:00:00Z"
-  },
+  "date": "2020-06-03",
   "shares": 1,
   "amount": 688.8,
   "grossAmount": 771.04,
@@ -26682,9 +24284,7 @@
   "type": "Buy",
   "company": "ANSYS INC. DL-,01",
   "symbol": "ANSS",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 4,
   "amount": 1019.6,
   "grossAmount": 1144,
@@ -26705,9 +24305,7 @@
   "type": "Buy",
   "company": "MASIMO CORP. DL-,001",
   "symbol": "MASI",
-  "date": {
-    "$date": "2020-08-13T00:00:00Z"
-  },
+  "date": "2020-08-13",
   "shares": 6,
   "amount": 1074,
   "grossAmount": 1264.2,
@@ -26728,9 +24326,7 @@
   "type": "Buy",
   "company": "MASIMO CORP. DL-,001",
   "symbol": "MASI",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 6,
   "amount": 1176,
   "grossAmount": 1337.7,
@@ -26751,9 +24347,7 @@
   "type": "Buy",
   "company": "CHRISTIAN HANSEN HL.DK 10",
   "symbol": "CHR.CO",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 12,
   "amount": 1064.88,
   "grossAmount": 7939,
@@ -26774,9 +24368,7 @@
   "type": "Buy",
   "company": "CHRISTIAN HANSEN HL.DK 10",
   "symbol": "CHR.CO",
-  "date": {
-    "$date": "2020-10-01T00:00:00Z"
-  },
+  "date": "2020-10-01",
   "shares": 11,
   "amount": 1010.9,
   "grossAmount": 7527.35,
@@ -26797,9 +24389,7 @@
   "type": "Buy",
   "company": "SIMCORP A/S NAM. DK 1",
   "symbol": "SIM.CO",
-  "date": {
-    "$date": "2020-06-16T00:00:00Z"
-  },
+  "date": "2020-06-16",
   "shares": 11,
   "amount": 1024.1,
   "grossAmount": 7635.62,
@@ -26820,9 +24410,7 @@
   "type": "Buy",
   "company": "ABCAM PLC LS -,002",
   "symbol": "ABC.L",
-  "date": {
-    "$date": "2020-06-16T00:00:00Z"
-  },
+  "date": "2020-06-16",
   "shares": 69,
   "amount": 1001.88,
   "grossAmount": 89816.61,
@@ -26843,9 +24431,7 @@
   "type": "Buy",
   "company": "ABCAM PLC LS -,002",
   "symbol": "ABC.L",
-  "date": {
-    "$date": "2020-07-23T00:00:00Z"
-  },
+  "date": "2020-07-23",
   "shares": 68,
   "amount": 1003,
   "grossAmount": 91395.94,
@@ -26866,9 +24452,7 @@
   "type": "Buy",
   "company": "ABCAM PLC LS -,002",
   "symbol": "ABC.L",
-  "date": {
-    "$date": "2020-09-22T00:00:00Z"
-  },
+  "date": "2020-09-22",
   "shares": 80,
   "amount": 1003.2,
   "grossAmount": 92036.8,
@@ -26889,9 +24473,7 @@
   "type": "Buy",
   "company": "PAYCOM SOFTWARE DL -,01",
   "symbol": "PAYC",
-  "date": {
-    "$date": "2020-06-17T00:00:00Z"
-  },
+  "date": "2020-06-17",
   "shares": 4,
   "amount": 1123.2,
   "grossAmount": 1261.58,
@@ -26912,9 +24494,7 @@
   "type": "Buy",
   "company": "PAYCOM SOFTWARE DL -,01",
   "symbol": "PAYC",
-  "date": {
-    "$date": "2020-07-14T00:00:00Z"
-  },
+  "date": "2020-07-14",
   "shares": 5,
   "amount": 1255.5,
   "grossAmount": 1428.13,
@@ -26935,9 +24515,7 @@
   "type": "Buy",
   "company": "DEXCOM INC. DL-,001",
   "symbol": "DXCM",
-  "date": {
-    "$date": "2020-06-17T00:00:00Z"
-  },
+  "date": "2020-06-17",
   "shares": 3,
   "amount": 1079.1,
   "grossAmount": 1212.05,
@@ -26958,9 +24536,7 @@
   "type": "Buy",
   "company": "DEXCOM INC. DL-,001",
   "symbol": "DXCM",
-  "date": {
-    "$date": "2020-09-24T00:00:00Z"
-  },
+  "date": "2020-09-24",
   "shares": 3,
   "amount": 988.5,
   "grossAmount": 1155.75,
@@ -26981,9 +24557,7 @@
   "type": "Buy",
   "company": "PAYCOM SOFTWARE DL -,01",
   "symbol": "PAYC",
-  "date": {
-    "$date": "2020-09-04T00:00:00Z"
-  },
+  "date": "2020-09-04",
   "shares": 4,
   "amount": 938.4,
   "grossAmount": 1111.25,
@@ -27004,9 +24578,7 @@
   "type": "Buy",
   "company": "SALESFORCE.COM DL-,001",
   "symbol": "CRM",
-  "date": {
-    "$date": "2020-06-18T00:00:00Z"
-  },
+  "date": "2020-06-18",
   "shares": 6,
   "amount": 992.4,
   "grossAmount": 1113.67,
@@ -27027,9 +24599,7 @@
   "type": "Buy",
   "company": "EDWARDS LIFESCIENCES",
   "symbol": "EW",
-  "date": {
-    "$date": "2020-06-22T00:00:00Z"
-  },
+  "date": "2020-06-22",
   "shares": 16,
   "amount": 986.72,
   "grossAmount": 1106.41,
@@ -27050,9 +24620,7 @@
   "type": "Buy",
   "company": "ADIDAS AG NA O.N.",
   "symbol": "ADS.DE",
-  "date": {
-    "$date": "2020-06-26T00:00:00Z"
-  },
+  "date": "2020-06-26",
   "shares": 5,
   "amount": 1165.5,
   "grossAmount": 0,
@@ -27073,9 +24641,7 @@
   "type": "Buy",
   "company": "RIGHTMOVE PLC LS -,001",
   "symbol": "RMV.L",
-  "date": {
-    "$date": "2020-06-25T00:00:00Z"
-  },
+  "date": "2020-06-25",
   "shares": 167,
   "amount": 995.99,
   "grossAmount": 89980.43,
@@ -27096,9 +24662,7 @@
   "type": "Buy",
   "company": "ATLASSIAN CORP. A DL -,10",
   "symbol": "TEAM",
-  "date": {
-    "$date": "2020-06-29T00:00:00Z"
-  },
+  "date": "2020-06-29",
   "shares": 6,
   "amount": 935.88,
   "grossAmount": 1049.4,
@@ -27119,9 +24683,7 @@
   "type": "Buy",
   "company": "ATLASSIAN CORP. A DL -,10",
   "symbol": "TEAM",
-  "date": {
-    "$date": "2020-08-11T00:00:00Z"
-  },
+  "date": "2020-08-11",
   "shares": 7,
   "amount": 976.22,
   "grossAmount": 1148.33,
@@ -27142,9 +24704,7 @@
   "type": "Buy",
   "company": "THERMO FISH.SCIENTIF.DL 1",
   "symbol": "TMO",
-  "date": {
-    "$date": "2020-06-29T00:00:00Z"
-  },
+  "date": "2020-06-29",
   "shares": 3,
   "amount": 938.85,
   "grossAmount": 1052.73,
@@ -27165,9 +24725,7 @@
   "type": "Buy",
   "company": "HERMES INTERNATIONAL O.N.",
   "symbol": "RMS.PA",
-  "date": {
-    "$date": "2020-06-29T00:00:00Z"
-  },
+  "date": "2020-06-29",
   "shares": 1,
   "amount": 740.4,
   "grossAmount": 0,
@@ -27188,9 +24746,7 @@
   "type": "Buy",
   "company": "HERMES INTERNATIONAL O.N.",
   "symbol": "RMS.PA",
-  "date": {
-    "$date": "2020-08-03T00:00:00Z"
-  },
+  "date": "2020-08-03",
   "shares": 1,
   "amount": 692.2,
   "grossAmount": 0,
@@ -27211,9 +24767,7 @@
   "type": "Buy",
   "company": "CHEGG INC. DL -,001",
   "symbol": "CHGG",
-  "date": {
-    "$date": "2020-07-22T00:00:00Z"
-  },
+  "date": "2020-07-22",
   "shares": 15,
   "amount": 986.85,
   "grossAmount": 1129.25,
@@ -27234,9 +24788,7 @@
   "type": "Buy",
   "company": "CHEGG INC. DL -,001",
   "symbol": "CHGG",
-  "date": {
-    "$date": "2020-09-02T00:00:00Z"
-  },
+  "date": "2020-09-02",
   "shares": 16,
   "amount": 1033.92,
   "grossAmount": 1239.36,
@@ -27257,9 +24809,7 @@
   "type": "Buy",
   "company": "CHEGG INC. DL -,001",
   "symbol": "CHGG",
-  "date": {
-    "$date": "2020-09-18T00:00:00Z"
-  },
+  "date": "2020-09-18",
   "shares": 18,
   "amount": 975.78,
   "grossAmount": 1154.64,
@@ -27280,9 +24830,7 @@
   "type": "Buy",
   "company": "SERVICENOW INC. DL-,001",
   "symbol": "NOW",
-  "date": {
-    "$date": "2020-07-24T00:00:00Z"
-  },
+  "date": "2020-07-24",
   "shares": 3,
   "amount": 1083.3,
   "grossAmount": 1253.27,
@@ -27303,9 +24851,7 @@
   "type": "Buy",
   "company": "COPART INC.",
   "symbol": "CPRT",
-  "date": {
-    "$date": "2020-08-28T00:00:00Z"
-  },
+  "date": "2020-08-28",
   "shares": 11,
   "amount": 962.5,
   "grossAmount": 1136.33,
@@ -27326,9 +24872,7 @@
   "type": "Buy",
   "company": "LONZA GROUP AG NA SF 1",
   "symbol": "LONN.SW",
-  "date": {
-    "$date": "2020-08-04T00:00:00Z"
-  },
+  "date": "2020-08-04",
   "shares": 2,
   "amount": 1054.8,
   "grossAmount": 1137.5,
@@ -27349,9 +24893,7 @@
   "type": "Buy",
   "company": "ICON PLC EO-,06",
   "symbol": "ICLR",
-  "date": {
-    "$date": "2020-08-31T00:00:00Z"
-  },
+  "date": "2020-08-31",
   "shares": 10,
   "amount": 1560,
   "grossAmount": 1862.64,
@@ -27372,9 +24914,7 @@
   "type": "Buy",
   "company": "DANAHER CORP. DL-,01",
   "symbol": "DHR",
-  "date": {
-    "$date": "2020-09-03T00:00:00Z"
-  },
+  "date": "2020-09-03",
   "shares": 6,
   "amount": 1044.24,
   "grossAmount": 1238.57,
@@ -27395,9 +24935,7 @@
   "type": "Buy",
   "company": "TEMENOS AG NAM. SF 5",
   "symbol": "TEMN.SW",
-  "date": {
-    "$date": "2020-09-23T00:00:00Z"
-  },
+  "date": "2020-09-23",
   "shares": 9,
   "amount": 1077.3,
   "grossAmount": 1157.88,
@@ -27418,9 +24956,7 @@
   "type": "Buy",
   "company": "TEMENOS AG NAM. SF 5",
   "symbol": "TEMN.SW",
-  "date": {
-    "$date": "2020-10-01T00:00:00Z"
-  },
+  "date": "2020-10-01",
   "shares": 9,
   "amount": 1001.25,
   "grossAmount": 1081.75,
@@ -27441,9 +24977,7 @@
   "type": "Buy",
   "company": "CSL LTD",
   "symbol": "CSL.AX",
-  "date": {
-    "$date": "2020-10-05T00:00:00Z"
-  },
+  "date": "2020-10-05",
   "shares": 6,
   "amount": 1056.48,
   "grossAmount": 1729.67,
@@ -27464,9 +24998,7 @@
   "type": "Buy",
   "company": "SAP SE O.N.",
   "symbol": "SAP.DE",
-  "date": {
-    "$date": "2019-07-23T00:00:00Z"
-  },
+  "date": "2019-07-23",
   "shares": 25,
   "amount": 2808,
   "grossAmount": 0,
@@ -27487,9 +25019,7 @@
   "type": "Buy",
   "company": "ASML HOLDING EO -,09",
   "symbol": "ASML.AS",
-  "date": {
-    "$date": "2019-07-31T00:00:00Z"
-  },
+  "date": "2019-07-31",
   "shares": 12,
   "amount": 2455.41,
   "grossAmount": 0,
@@ -27510,9 +25040,7 @@
   "type": "Buy",
   "company": "ESTEE LAUDER COS A DL-,01",
   "symbol": "EL",
-  "date": {
-    "$date": "2019-07-31T00:00:00Z"
-  },
+  "date": "2019-07-31",
   "shares": 15,
   "amount": 2514.66,
   "grossAmount": 2804.1,
@@ -27533,9 +25061,7 @@
   "type": "Buy",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2019-07-31T00:00:00Z"
-  },
+  "date": "2019-07-31",
   "shares": 11,
   "amount": 2557.21,
   "grossAmount": 2851.54,
@@ -27556,9 +25082,7 @@
   "type": "Buy",
   "company": "TENCENT HLDGS HD-,00002",
   "symbol": "0700.HK",
-  "date": {
-    "$date": "2019-07-31T00:00:00Z"
-  },
+  "date": "2019-07-31",
   "shares": 60,
   "amount": 2546.24,
   "grossAmount": 22225.87,
@@ -27579,9 +25103,7 @@
   "type": "Buy",
   "company": "AUTOM. DATA PROC. DL -,10",
   "symbol": "ADP",
-  "date": {
-    "$date": "2019-07-31T00:00:00Z"
-  },
+  "date": "2019-07-31",
   "shares": 16,
   "amount": 2454.21,
   "grossAmount": 2736.69,
@@ -27602,9 +25124,7 @@
   "type": "Buy",
   "company": "TENCENT HLDGS HD-,00002",
   "symbol": "0700.HK",
-  "date": {
-    "$date": "2019-08-06T00:00:00Z"
-  },
+  "date": "2019-08-06",
   "shares": 40,
   "amount": 1550.76,
   "grossAmount": 13590.55,
@@ -27625,9 +25145,7 @@
   "type": "Buy",
   "company": "ASML HOLDING EO -,09",
   "symbol": "ASML.AS",
-  "date": {
-    "$date": "2019-08-14T00:00:00Z"
-  },
+  "date": "2019-08-14",
   "shares": 8,
   "amount": 1499.19,
   "grossAmount": 0,
@@ -27648,9 +25166,7 @@
   "type": "Buy",
   "company": "Inditex",
   "symbol": "ITX.MC",
-  "date": {
-    "$date": "2019-08-22T00:00:00Z"
-  },
+  "date": "2019-08-22",
   "shares": 90,
   "amount": 2483.38,
   "grossAmount": 0,
@@ -27671,9 +25187,7 @@
   "type": "Buy",
   "company": "SAP SE O.N.",
   "symbol": "SAP.DE",
-  "date": {
-    "$date": "2019-08-26T00:00:00Z"
-  },
+  "date": "2019-08-26",
   "shares": 14,
   "amount": 1500.47,
   "grossAmount": 0,
@@ -27694,9 +25208,7 @@
   "type": "Buy",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2019-09-03T00:00:00Z"
-  },
+  "date": "2019-09-03",
   "shares": 7,
   "amount": 1604.19,
   "grossAmount": 1754.5,
@@ -27717,9 +25229,7 @@
   "type": "Buy",
   "company": "EXPERIAN PLC DL -,10",
   "symbol": "EXPN.L",
-  "date": {
-    "$date": "2019-09-10T00:00:00Z"
-  },
+  "date": "2019-09-10",
   "shares": 90,
   "amount": 2492.4,
   "grossAmount": 222509.01,
@@ -27740,9 +25250,7 @@
   "type": "Buy",
   "company": "AUTOM. DATA PROC. DL -,10",
   "symbol": "ADP",
-  "date": {
-    "$date": "2019-09-10T00:00:00Z"
-  },
+  "date": "2019-09-10",
   "shares": 10,
   "amount": 1494.62,
   "grossAmount": 1649.01,
@@ -27763,9 +25271,7 @@
   "type": "Buy",
   "company": "LINDE PLC EO 0,001",
   "symbol": "LIN.DE",
-  "date": {
-    "$date": "2019-10-02T00:00:00Z"
-  },
+  "date": "2019-10-02",
   "shares": 15,
   "amount": 2522.18,
   "grossAmount": 0,
@@ -27786,9 +25292,7 @@
   "type": "Buy",
   "company": "ESTEE LAUDER COS A DL-,01",
   "symbol": "EL",
-  "date": {
-    "$date": "2019-10-18T00:00:00Z"
-  },
+  "date": "2019-10-18",
   "shares": 9,
   "amount": 1506.97,
   "grossAmount": 1674.7,
@@ -27809,9 +25313,7 @@
   "type": "Buy",
   "company": "EXPERIAN PLC DL -,10",
   "symbol": "EXPN.L",
-  "date": {
-    "$date": "2019-10-18T00:00:00Z"
-  },
+  "date": "2019-10-18",
   "shares": 55,
   "amount": 1518.42,
   "grossAmount": 131859.59,
@@ -27832,9 +25334,7 @@
   "type": "Buy",
   "company": "Inditex",
   "symbol": "ITX.MC",
-  "date": {
-    "$date": "2019-11-08T00:00:00Z"
-  },
+  "date": "2019-11-08",
   "shares": 18,
   "amount": 497.62,
   "grossAmount": 0,
@@ -27855,9 +25355,7 @@
   "type": "Buy",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2019-11-08T00:00:00Z"
-  },
+  "date": "2019-11-08",
   "shares": 2,
   "amount": 447.3,
   "grossAmount": 493.55,
@@ -27878,9 +25376,7 @@
   "type": "Buy",
   "company": "MOODY'S CORP DL-,01",
   "symbol": "MCO",
-  "date": {
-    "$date": "2019-11-13T00:00:00Z"
-  },
+  "date": "2019-11-13",
   "shares": 5,
   "amount": 999.1,
   "grossAmount": 1100.51,
@@ -27901,9 +25397,7 @@
   "type": "Buy",
   "company": "EQUINIX INC. DL-,001",
   "symbol": "EQIX",
-  "date": {
-    "$date": "2019-11-14T00:00:00Z"
-  },
+  "date": "2019-11-14",
   "shares": 2,
   "amount": 990.2,
   "grossAmount": 1089.81,
@@ -27924,9 +25418,7 @@
   "type": "Buy",
   "company": "KERING S.A. INH. EO 4",
   "symbol": "KER.PA",
-  "date": {
-    "$date": "2020-01-27T00:00:00Z"
-  },
+  "date": "2020-01-27",
   "shares": 2,
   "amount": 1104.1,
   "grossAmount": 0,
@@ -27947,9 +25439,7 @@
   "type": "Buy",
   "company": "SARTOR.STED.B. EO-,20",
   "symbol": "DIM.PA",
-  "date": {
-    "$date": "2020-01-27T00:00:00Z"
-  },
+  "date": "2020-01-27",
   "shares": 4,
   "amount": 650.14,
   "grossAmount": 0,
@@ -27970,9 +25460,7 @@
   "type": "Buy",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2020-02-07T00:00:00Z"
-  },
+  "date": "2020-02-07",
   "shares": 4,
   "amount": 917,
   "grossAmount": 1008.98,
@@ -27993,9 +25481,7 @@
   "type": "Buy",
   "company": "Bio-Techne",
   "symbol": "TECH",
-  "date": {
-    "$date": "2020-02-10T00:00:00Z"
-  },
+  "date": "2020-02-10",
   "shares": 3,
   "amount": 559,
   "grossAmount": 613.17,
@@ -28016,9 +25502,7 @@
   "type": "Buy",
   "company": "KERING S.A. INH. EO 4",
   "symbol": "KER.PA",
-  "date": {
-    "$date": "2020-03-02T00:00:00Z"
-  },
+  "date": "2020-03-02",
   "shares": 1,
   "amount": 501.35,
   "grossAmount": 0,
@@ -28039,9 +25523,7 @@
   "type": "Buy",
   "company": "PARTNERS GR.HLDG SF -,01",
   "symbol": "PGHN.SW",
-  "date": {
-    "$date": "2020-02-20T00:00:00Z"
-  },
+  "date": "2020-02-20",
   "shares": 2,
   "amount": 1822.7,
   "grossAmount": 1935.89,
@@ -28062,9 +25544,7 @@
   "type": "Buy",
   "company": "SAP SE O.N.",
   "symbol": "SAP.DE",
-  "date": {
-    "$date": "2020-03-06T00:00:00Z"
-  },
+  "date": "2020-03-06",
   "shares": 5,
   "amount": 530.7,
   "grossAmount": 0,
@@ -28085,9 +25565,7 @@
   "type": "Buy",
   "company": "BECTON, DICKINSON DL 1",
   "symbol": "BDX",
-  "date": {
-    "$date": "2020-03-06T00:00:00Z"
-  },
+  "date": "2020-03-06",
   "shares": 3,
   "amount": 627.25,
   "grossAmount": 701.7,
@@ -28108,9 +25586,7 @@
   "type": "Buy",
   "company": "LINDE PLC EO 0,001",
   "symbol": "LIN.DE",
-  "date": {
-    "$date": "2020-03-09T00:00:00Z"
-  },
+  "date": "2020-03-09",
   "shares": 4,
   "amount": 605,
   "grossAmount": 0,
@@ -28131,9 +25607,7 @@
   "type": "Buy",
   "company": "MOODY'S CORP DL-,01",
   "symbol": "MCO",
-  "date": {
-    "$date": "2020-03-09T00:00:00Z"
-  },
+  "date": "2020-03-09",
   "shares": 2,
   "amount": 392,
   "grossAmount": 444.37,
@@ -28154,9 +25628,7 @@
   "type": "Buy",
   "company": "PARTNERS GR.HLDG SF -,01",
   "symbol": "PGHN.SW",
-  "date": {
-    "$date": "2020-03-09T00:00:00Z"
-  },
+  "date": "2020-03-09",
   "shares": 2,
   "amount": 1467.5,
   "grossAmount": 1554.67,
@@ -28177,9 +25649,7 @@
   "type": "Buy",
   "company": "ESTEE LAUDER COS A DL-,01",
   "symbol": "EL",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 5,
   "amount": 741.1,
   "grossAmount": 741.1,
@@ -28200,9 +25670,7 @@
   "type": "Buy",
   "company": "KERING S.A. INH. EO 4",
   "symbol": "KER.PA",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 2,
   "amount": 841.32,
   "grossAmount": 0,
@@ -28223,9 +25691,7 @@
   "type": "Buy",
   "company": "AUTOM. DATA PROC. DL -,10",
   "symbol": "ADP",
-  "date": {
-    "$date": "2020-03-12T00:00:00Z"
-  },
+  "date": "2020-03-12",
   "shares": 8,
   "amount": 1000,
   "grossAmount": 1000,
@@ -28246,9 +25712,7 @@
   "type": "Buy",
   "company": "EXPERIAN PLC DL -,10",
   "symbol": "EXPN.L",
-  "date": {
-    "$date": "2020-03-16T00:00:00Z"
-  },
+  "date": "2020-03-16",
   "shares": 23,
   "amount": 509.45,
   "grossAmount": 44551,
@@ -28269,9 +25733,7 @@
   "type": "Buy",
   "company": "SARTOR.STED.B. EO-,20",
   "symbol": "DIM.PA",
-  "date": {
-    "$date": "2020-03-16T00:00:00Z"
-  },
+  "date": "2020-03-16",
   "shares": 4,
   "amount": 552,
   "grossAmount": 0,
@@ -28292,9 +25754,7 @@
   "type": "Buy",
   "company": "Inditex",
   "symbol": "ITX.MC",
-  "date": {
-    "$date": "2020-03-16T00:00:00Z"
-  },
+  "date": "2020-03-16",
   "shares": 26,
   "amount": 501.8,
   "grossAmount": 0,
@@ -28315,9 +25775,7 @@
   "type": "Buy",
   "company": "MOODY'S CORP DL-,01",
   "symbol": "MCO",
-  "date": {
-    "$date": "2020-03-18T00:00:00Z"
-  },
+  "date": "2020-03-18",
   "shares": 6,
   "amount": 938.64,
   "grossAmount": 1002.18,
@@ -28338,9 +25796,7 @@
   "type": "Buy",
   "company": "Bio-Techne",
   "symbol": "TECH",
-  "date": {
-    "$date": "2020-03-24T00:00:00Z"
-  },
+  "date": "2020-03-24",
   "shares": 4,
   "amount": 328,
   "grossAmount": 328,
@@ -28361,9 +25817,7 @@
   "type": "Buy",
   "company": "GUIDEWIRE SOFTWA.DL-,0001",
   "symbol": "GWRE",
-  "date": {
-    "$date": "2020-04-09T00:00:00Z"
-  },
+  "date": "2020-04-09",
   "shares": 10,
   "amount": 775,
   "grossAmount": 842.5,
@@ -28384,9 +25838,7 @@
   "type": "Sell",
   "company": "Inditex",
   "symbol": "ITX.MC",
-  "date": {
-    "$date": "2020-04-20T00:00:00Z"
-  },
+  "date": "2020-04-20",
   "shares": 134,
   "amount": 3331.24,
   "grossAmount": 0,
@@ -28407,9 +25859,7 @@
   "type": "Buy",
   "company": "ROPER TECHNOLOGIES DL-,01",
   "symbol": "ROP",
-  "date": {
-    "$date": "2020-04-20T00:00:00Z"
-  },
+  "date": "2020-04-20",
   "shares": 4,
   "amount": 1176,
   "grossAmount": 1297.36,
@@ -28430,9 +25880,7 @@
   "type": "Buy",
   "company": "VISA INC. CL. A DL -,0001",
   "symbol": "V",
-  "date": {
-    "$date": "2020-05-12T00:00:00Z"
-  },
+  "date": "2020-05-12",
   "shares": 6,
   "amount": 1009.8,
   "grossAmount": 1093.01,
@@ -28453,9 +25901,7 @@
   "type": "Buy",
   "company": "TAIWAN SEMICON.MANU.ADR/5",
   "symbol": "TSM",
-  "date": {
-    "$date": "2020-05-15T00:00:00Z"
-  },
+  "date": "2020-05-15",
   "shares": 21,
   "amount": 989.1,
   "grossAmount": 989.1,
@@ -28476,9 +25922,7 @@
   "type": "Buy",
   "company": "JACK HENRY + ASS. DL -,01",
   "symbol": "JKHY",
-  "date": {
-    "$date": "2020-05-29T00:00:00Z"
-  },
+  "date": "2020-05-29",
   "shares": 4,
   "amount": 644,
   "grossAmount": 715,
@@ -28499,9 +25943,7 @@
   "type": "Buy",
   "company": "HEICO CORP. DL-,01",
   "symbol": "HEI",
-  "date": {
-    "$date": "2020-05-29T00:00:00Z"
-  },
+  "date": "2020-05-29",
   "shares": 6,
   "amount": 550.2,
   "grossAmount": 614.04,
@@ -28522,9 +25964,7 @@
   "type": "Buy",
   "company": "MARKETAXESS HLDGS DL-,001",
   "symbol": "MKTX",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 3,
   "amount": 1317.3,
   "grossAmount": 1478.37,
@@ -28545,9 +25985,7 @@
   "type": "Buy",
   "company": "VERISK ANALYTICS DL-001",
   "symbol": "VRSK",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 7,
   "amount": 1056.58,
   "grossAmount": 1201.86,
@@ -28568,9 +26006,7 @@
   "type": "Buy",
   "company": "MSCI INC. A DL-,01",
   "symbol": "MSCI",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 4,
   "amount": 1160,
   "grossAmount": 1319.52,
@@ -28591,9 +26027,7 @@
   "type": "Buy",
   "company": "COGNEX CORP. DL-,002",
   "symbol": "CGNX",
-  "date": {
-    "$date": "2020-06-16T00:00:00Z"
-  },
+  "date": "2020-06-16",
   "shares": 20,
   "amount": 1016.8,
   "grossAmount": 1149.8,
@@ -28614,9 +26048,7 @@
   "type": "Buy",
   "company": "IHS MARKIT LTD DL -,01",
   "symbol": "INFO",
-  "date": {
-    "$date": "2020-06-16T00:00:00Z"
-  },
+  "date": "2020-06-16",
   "shares": 16,
   "amount": 1032,
   "grossAmount": 1159.14,
@@ -28637,9 +26069,7 @@
   "type": "Buy",
   "company": "NVIDIA CORP. DL-,001",
   "symbol": "NVDA",
-  "date": {
-    "$date": "2020-06-19T00:00:00Z"
-  },
+  "date": "2020-06-19",
   "shares": 3,
   "amount": 1005.6,
   "grossAmount": 1127.28,
@@ -28660,9 +26090,7 @@
   "type": "Buy",
   "company": "STARBUCKS CORP.",
   "symbol": "SBUX",
-  "date": {
-    "$date": "2020-06-22T00:00:00Z"
-  },
+  "date": "2020-06-22",
   "shares": 15,
   "amount": 992.7,
   "grossAmount": 1113.12,
@@ -28683,9 +26111,7 @@
   "type": "Sell",
   "company": "Bio-Techne",
   "symbol": "TECH",
-  "date": {
-    "$date": "2020-06-23T00:00:00Z"
-  },
+  "date": "2020-06-23",
   "shares": 7,
   "amount": 1624,
   "grossAmount": 1820.99,
@@ -28706,9 +26132,7 @@
   "type": "Buy",
   "company": "VERISK ANALYTICS DL-001",
   "symbol": "VRSK",
-  "date": {
-    "$date": "2020-06-23T00:00:00Z"
-  },
+  "date": "2020-06-23",
   "shares": 7,
   "amount": 1035.58,
   "grossAmount": 1161.2,
@@ -28729,9 +26153,7 @@
   "type": "Buy",
   "company": "HEICO CORP. DL-,01",
   "symbol": "HEI",
-  "date": {
-    "$date": "2020-06-24T00:00:00Z"
-  },
+  "date": "2020-06-24",
   "shares": 11,
   "amount": 980.32,
   "grossAmount": 1105.8,
@@ -28752,9 +26174,7 @@
   "type": "Buy",
   "company": "ABBOTT LABS",
   "symbol": "ABT",
-  "date": {
-    "$date": "2020-06-24T00:00:00Z"
-  },
+  "date": "2020-06-24",
   "shares": 14,
   "amount": 1090.04,
   "grossAmount": 1229.56,
@@ -28775,9 +26195,7 @@
   "type": "Buy",
   "company": "FIDELITY NATL INF. SVCS",
   "symbol": "FIS",
-  "date": {
-    "$date": "2020-06-26T00:00:00Z"
-  },
+  "date": "2020-06-26",
   "shares": 8,
   "amount": 951.84,
   "grossAmount": 1067.3,
@@ -28798,9 +26216,7 @@
   "type": "Buy",
   "company": "VISA INC. CL. A DL -,0001",
   "symbol": "V",
-  "date": {
-    "$date": "2020-07-14T00:00:00Z"
-  },
+  "date": "2020-07-14",
   "shares": 6,
   "amount": 993.48,
   "grossAmount": 1130.08,
@@ -28821,9 +26237,7 @@
   "type": "Buy",
   "company": "JACK HENRY + ASS. DL -,01",
   "symbol": "JKHY",
-  "date": {
-    "$date": "2020-07-16T00:00:00Z"
-  },
+  "date": "2020-07-16",
   "shares": 6,
   "amount": 942.6,
   "grossAmount": 1078.71,
@@ -28844,9 +26258,7 @@
   "type": "Buy",
   "company": "AUTOM. DATA PROC. DL -,10",
   "symbol": "ADP",
-  "date": {
-    "$date": "2020-07-29T00:00:00Z"
-  },
+  "date": "2020-07-29",
   "shares": 9,
   "amount": 1069.02,
   "grossAmount": 1252.57,
@@ -28867,9 +26279,7 @@
   "type": "Buy",
   "company": "HEICO CORP. DL-,01",
   "symbol": "HEI",
-  "date": {
-    "$date": "2020-07-29T00:00:00Z"
-  },
+  "date": "2020-07-29",
   "shares": 12,
   "amount": 967.2,
   "grossAmount": 1133.27,
@@ -28890,9 +26300,7 @@
   "type": "Buy",
   "company": "JACK HENRY + ASS. DL -,01",
   "symbol": "JKHY",
-  "date": {
-    "$date": "2020-08-21T00:00:00Z"
-  },
+  "date": "2020-08-21",
   "shares": 7,
   "amount": 994.7,
   "grossAmount": 1170.66,
@@ -28913,9 +26321,7 @@
   "type": "Buy",
   "company": "MARKETAXESS HLDGS DL-,001",
   "symbol": "MKTX",
-  "date": {
-    "$date": "2020-08-25T00:00:00Z"
-  },
+  "date": "2020-08-25",
   "shares": 3,
   "amount": 1237.2,
   "grossAmount": 1461.63,
@@ -28936,9 +26342,7 @@
   "type": "Sell",
   "company": "KERING S.A. INH. EO 4",
   "symbol": "KER.PA",
-  "date": {
-    "$date": "2020-08-31T00:00:00Z"
-  },
+  "date": "2020-08-31",
   "shares": 5,
   "amount": 2575.5,
   "grossAmount": 0,
@@ -28959,9 +26363,7 @@
   "type": "Buy",
   "company": "VISA INC. CL. A DL -,0001",
   "symbol": "V",
-  "date": {
-    "$date": "2020-09-24T00:00:00Z"
-  },
+  "date": "2020-09-24",
   "shares": 6,
   "amount": 1003.08,
   "grossAmount": 1172.8,
@@ -28982,9 +26384,7 @@
   "type": "Buy",
   "company": "BOOKING HLDGS DL-,008",
   "symbol": "BKNG",
-  "date": {
-    "$date": "2017-08-09T00:00:00Z"
-  },
+  "date": "2017-08-09",
   "shares": 2,
   "amount": 3234.5,
   "grossAmount": 3794.39,
@@ -29005,9 +26405,7 @@
   "type": "Buy",
   "company": "BOOKING HLDGS DL-,008",
   "symbol": "BKNG",
-  "date": {
-    "$date": "2017-11-07T00:00:00Z"
-  },
+  "date": "2017-11-07",
   "shares": 1,
   "amount": 1462.2,
   "grossAmount": 1690.6,
@@ -29028,9 +26426,7 @@
   "type": "Buy",
   "company": "BOOKING HLDGS DL-,008",
   "symbol": "BKNG",
-  "date": {
-    "$date": "2019-05-24T00:00:00Z"
-  },
+  "date": "2019-05-24",
   "shares": 1,
   "amount": 1544.34,
   "grossAmount": 1727.65,
@@ -29051,9 +26447,7 @@
   "type": "Buy",
   "company": "BOOKING HLDGS DL-,008",
   "symbol": "BKNG",
-  "date": {
-    "$date": "2020-03-19T00:00:00Z"
-  },
+  "date": "2020-03-19",
   "shares": 1,
   "amount": 1068.8,
   "grossAmount": 1068.8,
@@ -29074,9 +26468,7 @@
   "type": "Buy",
   "company": "Canadian National Railway",
   "symbol": "CNI",
-  "date": {
-    "$date": "2019-09-20T00:00:00Z"
-  },
+  "date": "2019-09-20",
   "shares": 30,
   "amount": 2481.88,
   "grossAmount": 2746.7,
@@ -29097,9 +26489,7 @@
   "type": "Buy",
   "company": "Canadian National Railway",
   "symbol": "CNI",
-  "date": {
-    "$date": "2019-10-01T00:00:00Z"
-  },
+  "date": "2019-10-01",
   "shares": 20,
   "amount": 1617.32,
   "grossAmount": 1761.1,
@@ -29120,9 +26510,7 @@
   "type": "Sell",
   "company": "Canadian National Railway",
   "symbol": "CNI",
-  "date": {
-    "$date": "2020-02-18T00:00:00Z"
-  },
+  "date": "2020-02-18",
   "shares": 50,
   "amount": 4322.25,
   "grossAmount": 4683.16,
@@ -29143,9 +26531,7 @@
   "type": "Buy",
   "company": "Balchem",
   "symbol": "BCPC",
-  "date": {
-    "$date": "2020-02-20T00:00:00Z"
-  },
+  "date": "2020-02-20",
   "shares": 5,
   "amount": 520.5,
   "grossAmount": 562.14,
@@ -29166,9 +26552,7 @@
   "type": "Buy",
   "company": "Balchem",
   "symbol": "BCPC",
-  "date": {
-    "$date": "2020-02-24T00:00:00Z"
-  },
+  "date": "2020-02-24",
   "shares": 6,
   "amount": 555.1,
   "grossAmount": 599.56,
@@ -29189,9 +26573,7 @@
   "type": "Sell",
   "company": "Balchem",
   "symbol": "BCPC",
-  "date": {
-    "$date": "2020-06-10T00:00:00Z"
-  },
+  "date": "2020-06-10",
   "shares": 11,
   "amount": 992.86,
   "grossAmount": 1121.34,

--- a/benchmark/calcValueHistory/index.js
+++ b/benchmark/calcValueHistory/index.js
@@ -7,13 +7,19 @@ const quotes = require('./fixtures/quotes.json')
 
 const calcValueHistory = require('../../src/calcValueHistory')
 
-const activitiesFilered = activities.filter(a => ['Buy', 'Sell', 'split'].includes(a.type))
+const activitiesFilered = activities
+  .filter(a => ['Buy', 'Sell', 'split'].includes(a.type))
+  .map(a => ({
+    ...a,
+    date: new Date(a.date.$date)
+  }))
+
 const activitiesByHolding = groupBy(activitiesFilered, 'holding')
 
 function getEarliestActivity (values) {
   const earliest = minBy(values, x => new Date(x.date)) || {}
 
-  return new Date((earliest.date && earliest.date.$date) || new Date())
+  return new Date((earliest.date && earliest.date) || new Date())
 }
 
 const start = new Date()


### PR DESCRIPTION
The mock data export formatted `date` (real date object) as `date.$date` (string representation). 
That fix reverts that formatting.