### PR TITLE
change normalizedQuotes to use a temp var instead a full search for t…

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -45,27 +45,22 @@ function getDateArr (interval) {
 }
 
 function normalizeQuotes (quotes = [], dates) {
+  let prevprice = 0
+
   const quotesPerDay = dates.map(d => {
     const t = d
 
     // TODO: possible perf potential
     const q = find(quotes, x => x.date === t)
 
+    if (q && q.price) {
+      prevprice = q.price
+    }
+
     return {
       date: t,
-      price: q && q.price ? q.price : null
+      price: q && q.price ? q.price : prevprice
     }
-  })
-
-  // remove all null values by filling in previous day values
-  quotesPerDay.forEach((q, i) => {
-    if (q.price === null || q.price === undefined) {
-      q.price = getPreviousValue(
-        quotesPerDay.map(x => x.price),
-        i
-      )
-    }
-    return q
   })
 
   return quotesPerDay

--- a/utils.js
+++ b/utils.js
@@ -45,23 +45,31 @@ function getDateArr (interval) {
 }
 
 function normalizeQuotes (quotes = [], dates) {
-  let prevprice = 0
+  let price = 0
 
-  const quotesPerDay = dates.map(d => {
-    const t = d
+  const quotesPerDay = []
+  let alreadyFindPrice = false
+
+  for (let i = 0; i < dates.length; i++) {
+    const t = dates[i]
 
     // TODO: possible perf potential
     const q = find(quotes, x => x.date === t)
 
     if (q && q.price) {
-      prevprice = q.price
+      price = q.price
+
+      if (!alreadyFindPrice) {
+        quotesPerDay.slice(0, i).map(q => q.price = price);
+        alreadyFindPrice = true
+      }
     }
 
-    return {
+    quotesPerDay.push({
       date: t,
-      price: q && q.price ? q.price : prevprice
-    }
-  })
+      price
+    })
+  }
 
   return quotesPerDay
 }

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,7 @@
 const cloneDeep = require('lodash/cloneDeep')
 const filter = require('lodash/filter')
 const find = require('lodash/find')
+const keyBy = require('lodash/keyBy')
 const Big = require('big.js')
 const {
   format,
@@ -44,24 +45,28 @@ function getDateArr (interval) {
   return dateArr
 }
 
+// iterate all dates verifing if it have a price in the quotes
+// we save the last founded price to fill the next dates without price
+// if a date dont have price it will be filled with the previous price we save
+// when the first price was found, if exists, we fill the firsts empty elements
+// the output will be the dates array and every day will have a price
 function normalizeQuotes (quotes = [], dates) {
+  quotes = keyBy(quotes, 'date')
   let price = 0
-
+  let priceFound = false
   const quotesPerDay = []
-  let alreadyFindPrice = false
 
   for (let i = 0; i < dates.length; i++) {
     const t = dates[i]
-
-    // TODO: possible perf potential
-    const q = find(quotes, x => x.date === t)
+    const q = quotes[t]
 
     if (q && q.price) {
       price = q.price
 
-      if (!alreadyFindPrice) {
+      // Fills empty starting values by take the first empty elements of the array and fill in the first price that was found.
+      if (!priceFound) {
         quotesPerDay.slice(0, i).map(q => q.price = price);
-        alreadyFindPrice = true
+        priceFound = true
       }
     }
 


### PR DESCRIPTION
hey guys, i changed normalizedQuotes to use a temp var instead a full search for the prev price and with just one iteration, i got a good result in benchmark.

Explanation: when a quote have the price i save it in **prev** var, on the next item if it dont have a price a set it to the **prev** saved price.

Benchmark:
![Captura de Tela 2020-10-27 às 14 58 33](https://user-images.githubusercontent.com/4966360/97348703-4a2e9200-186d-11eb-8090-b820dc70a499.png)

![image](https://user-images.githubusercontent.com/4966360/97349321-1acc5500-186e-11eb-8677-9bd11e374182.png)
